### PR TITLE
Add more gitignore entries.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ DiskInfo.VC.opendb
 DiskInfo.VC.db
 AtaSmart.cpp.rej
 DiskInfo.VC.VC.opendb
+*.aps
+*.user
+.vs/

--- a/DiskInfo.vcxproj
+++ b/DiskInfo.vcxproj
@@ -468,6 +468,8 @@
     <ClInclude Include="StorageQuery.h" />
   </ItemGroup>
   <ItemGroup>
+    <None Include=".gitattributes" />
+    <None Include=".gitignore" />
     <None Include="resN\DiskInfo.ico" />
     <None Include="resN\DiskInfo16.ico" />
     <None Include="resS\DiskInfo.ico" />

--- a/DiskInfo.vcxproj.filters
+++ b/DiskInfo.vcxproj.filters
@@ -860,6 +860,8 @@
       <Filter>Resource Files</Filter>
     </None>
     <None Include="res\001soundkenjin.opus" />
+    <None Include=".gitattributes" />
+    <None Include=".gitignore" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="DiskInfo.rc">


### PR DESCRIPTION
* apsファイルとuserファイルがリポジトリに入ってしまうので除外しました。
* （これはアドバイス） gitignoreは、公式のものを出来るだけそのまま使ったほうが、管理が楽ですよ。あっちはコミュニティが更新してくれるので（時々新しいのに入れ替える感じ）。後々CIとかやり始めようとするときに、面倒が一つ減ります。現在のワークディレクトリ構成が合わない可能性も多々あったりしますが、出来るだけ公式gitignoreで運用できるように合わせたほうが、後で悩まなくても済みます。  https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
