### PR TITLE
Crucial BX300 support

### DIFF
--- a/AtaSmart.cpp
+++ b/AtaSmart.cpp
@@ -4090,6 +4090,7 @@ BOOL CAtaSmart::IsSsdMicron(ATA_SMART_INFO &asi)
 		|| modelUpper.Find(_T("M4-")) == 0 || modelUpper.Find(_T("M400")) == 0
 		|| modelUpper.Find(_T("P300")) == 0 || modelUpper.Find(_T("C300")) == 0
 		|| modelUpper.Find(_T("M3-")) == 0 || modelUpper.Find(_T("M300")) == 0
+		|| (modelUpper.Find(_T("CT")) == 0 && modelUpper.Right(4) == _T("SSD1"))
 		|| modelUpper.Find(_T("CRUCIAL")) == 0 || modelUpper.Find(_T("MICRON")) == 0
 		|| flagSmartType;
 }


### PR DESCRIPTION
every attribute name matches:
![default](https://user-images.githubusercontent.com/5585684/35482535-f300c726-0471-11e8-8aa4-391879f52067.jpg)
