### PR TITLE
WD blue 3D NAND SSD support

### DIFF
--- a/AtaSmart.cpp
+++ b/AtaSmart.cpp
@@ -4329,7 +4329,9 @@ BOOL CAtaSmart::IsSsdSanDisk(ATA_SMART_INFO &asi)
 
 	// 2013/10/7
 	// https://crystalmark.info/bbs/c-board.cgi?cmd=one;no=1425;id=diskinfo#1425
-	if (asi.Model.Find(_T("SanDisk")) >= 0)
+	if (asi.Model.Find(_T("SanDisk")) >= 0
+		|| (asi.Model.Left(7)==_T("WDC WDS") && asi.Model.Find(_T("2B0")) == asi.Model.GetLength()-4)  // WD Blue 3D is the same as SanDisk Ultra 3D
+		)
 	{
 		flagSmartType = TRUE;
 		asi.SmartKeyName = _T("SmartSanDisk");
@@ -4340,6 +4342,7 @@ BOOL CAtaSmart::IsSsdSanDisk(ATA_SMART_INFO &asi)
 			{
 				asi.HostReadsWritesUnit = HOST_READS_WRITES_GB;
 				asi.SmartKeyName = _T("SmartSanDiskGb");
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
resolves #21; also fixed some "vendor specific" attributes of sandisk ultra 3d (but i can't figure out some "WD Internal" attributes)

language files:
english
```
[SmartSanDiskGb] ;Added 6.2.0
05=Reallocated Block Count
09=Power On Hours
0C=Power Cycle Count
A6=Min W/E Cycle
A7=Max Bad Block/Die
A8=Maximum Erase Cycle
A9=Total Bad Blocks
AA=Grown Bad Blocks
AB=Program Fail Count
AC=Erase Fail Count
AD=Average Erase Cycle
AE=Unexpected Power Loss Count
BB=Reported Uncorrectable Errors
BC=Command Timeout Count
C2=Temperature
D4=SATA PHY Error
C7=CRC Error Count
E6=Percentage Total P/E Count
E8=Spare Block Remaining
E9=Total GB written to NAND
EA=Total GB written to NAND (SLC)
F1=Total GB Written
F2=Total GB Read
F4=Temperature Throttle Status
```

simplified chinese
```
[SmartSanDiskGb] ;Added 6.2.0
05=重新分配块计数
09=通电时间
0C=启动-关闭循环次数
A6=最小写入/擦除循环数
A7=裸片中最大坏块数
A8=最大擦除循环
A9=坏块总计
AA=新增坏块计数
AB=编程失败计数
AC=擦除失败计数
AD=平均擦除循环
AE=意外断电计数
BB=报告的无法校正错误
BC=命令超时计数
C2=温度
D4=SATA 物理层错误计数
C7=CRC错误计数
E6=编程/擦除(P/E)总计 (百分比)
E8=剩余备用块
E9=对 NAND 写入量总计 (GB)
EA=对 SLC NAND 写入量总计 (GB)
F1=写入量总计(GB)
F2=读取量总计(GB)
F4=高温限制性能状态
```
![图片](https://user-images.githubusercontent.com/5585684/58027131-8b842380-7b4a-11e9-88d7-decdb847a499.png)

