### PR TITLE
AMD-RAIDXpert2対応

### DIFF
--- a/AtaSmart.cpp
+++ b/AtaSmart.cpp
@@ -7888,6 +7888,20 @@ BOOL CAtaSmart::AddDiskCsmi(INT scsiPort)
 		return FALSE;
 	}
 	memcpy(&phyInfo, &(phyInfoBuf.Information), sizeof(phyInfoBuf.Information));
+
+	// AMD-RAIDXpert2 support
+	if(memcmp(driverInfoBuf.Information.szName, "rcraid", 7) == 0)
+	{
+		for(UINT i = 0; i < raidInfoBuf.Information.uMaxPhysicalDrives; i++)
+		{
+			if(i >= phyInfo.bNumberOfPhys)
+			{
+				memcpy(&phyInfo.Phy[i], &phyInfo.Phy[0], sizeof(phyInfo.Phy[i]));
+			}
+			phyInfo.Phy[i].Attached.bPhyIdentifier = phyInfo.Phy[i].bPortIdentifier = i;
+		}
+		phyInfo.bNumberOfPhys = raidInfoBuf.Information.uMaxPhysicalDrives;
+	}
 	
 	IDENTIFY_DEVICE identify = {0};	
 	if(phyInfo.bNumberOfPhys <= sizeof(phyInfo.Phy)/sizeof(phyInfo.Phy[0]))


### PR DESCRIPTION
AMD-RAIDXpert2に対応しました。
物理ドライブとドライブレターの紐づけは未対応です。

確認環境
- ドライバ: AMD RAID (SATA) 9.2.0.127
- マザーボード: X399 Taichi

確認アレイ構成1
- アレイ1 RAID1
  - ディスク0
  - ディスク1
- アレイ1 LEGACY
  - ディスク4
- アレイ3 RAID0
  - ディスク2
  - ディスク3

確認アレイ構成2
- アレイ1 RAID1
  - ディスク0
  - ディスク1
- アレイ1 LEGACY
  - ディスク4
- アレイ3 RAID1
  - ディスク2
  - ディスク3

確認アレイ構成3
- アレイ1 RAID1
  - ディスク0
  - ディスク1
- アレイ1 LEGACY
  - ディスク4
- アレイ未構成(初期化済みディスク)
  - ディスク2
  - ディスク3

左から5つ目までのドライブがRAIDXpert2のドライバ経由で接続されているドライブ
(5つ目のドライブであるディスク4にはドライブレターEを割り当てているが、ドライブレター表示は未対応のため表示されていない)
![image](https://user-images.githubusercontent.com/7032792/64077677-9172ce80-cd0d-11e9-81e9-1e400f4a4b9a.png)
