### PR TITLE
記憶域スペース上のNVMe SSDの一覧表示に対応

### DIFF
--- a/AtaSmart.cpp
+++ b/AtaSmart.cpp
@@ -1818,6 +1818,11 @@ safeRelease:
 		{
 			firmware	= (char*)pDescriptor + pDescriptor->ProductRevisionOffset;
 		}
+		// [2019/10/28] Workaround for NVMe SSD on MS Storage Space
+		if(pDescriptor->BusType == BusTypeNvme)
+		{
+			interfaceType = INTERFACE_TYPE_NVME;
+		}
 
 		delete [] pcbData;
 

--- a/SlotSpeedGetter.cpp
+++ b/SlotSpeedGetter.cpp
@@ -84,9 +84,16 @@ CString GetDeviceIDFromPhysicalDriveID(const INT physicalDriveId, const BOOL IsK
 				{
 					query.Format(query2findstorage, physicalDriveId);
 					CString StorageID = GetStringValueFromQuery(pIWbemServices, query, L"DeviceID");
-					query.Format(query2findcontroller, StorageID);
-					CString ControllerID = GetStringValueFromQuery(pIWbemServices, query, L"DeviceID");
-					result = ControllerID;
+					if(!StorageID.IsEmpty())
+					{
+						query.Format(query2findcontroller, StorageID);
+						CString ControllerID = GetStringValueFromQuery(pIWbemServices, query, L"DeviceID");
+						result = ControllerID;
+					}
+					else
+					{
+						result = L"";
+					}
 				}
 			}
 		}


### PR DESCRIPTION
NVMe SSDを記憶域スペースに組み込むと、WMI Win32_DiskDrive の一覧に出てこなくなるため、回避策を追加しました。
現状、十分にテストが出来ているとは言えないのですが、「ストレージサイズ」と「対応転送モード」は取得出来ていませんが、その他は正しい値が表示できていそうです。

参考: [Win8記憶域プールとUSB HDD - CrystalDiskInfo 専用掲示板](https://crystalmark.info/bbs/c-board.cgi?cmd=one;no=1258;id=diskinfo)

![cdi_nvme_on_storage_space](https://user-images.githubusercontent.com/1449495/67686769-91740f80-f9da-11e9-8bb4-d5b9ff3fa304.png)

CrystalDiskMark 7 のリリース前でお忙しいかと思いますが、
お手すきの際にご確認頂ければと存じます。
