### PR TITLE
ウィンドウ位置の保存と復元

### DIFF
--- a/DiskInfoDlg.cpp
+++ b/DiskInfoDlg.cpp
@@ -397,6 +397,8 @@ void CDiskInfoDlg::OnCancel()
 	}
 	if(! m_bResident)
 	{
+		SavePos();
+
 		KillGraphDlg();
 		if(m_hDevNotify)
 		{
@@ -1521,6 +1523,19 @@ void CDiskInfoDlg::SetClientSize(int sizeX, int sizeY, double zoomRatio)
 
 		SetWindowPos(NULL, 0, 0, (int)(sizeX * zoomRatio) + ncaWidth, (int)(sizeY * zoomRatio) + ncaHeight, SWP_NOMOVE | SWP_NOZORDER);
 	}
+}
+
+void CDiskInfoDlg::SavePos() const
+{
+	WINDOWPLACEMENT place;
+	place.length = sizeof(WINDOWPLACEMENT);
+	GetWindowPlacement(&place);
+
+	CString x, y;
+	x.Format(_T("%d"), place.rcNormalPosition.left);
+	y.Format(_T("%d"), place.rcNormalPosition.top);
+	WritePrivateProfileString(_T("Setting"), _T("X"), x, m_Ini);
+	WritePrivateProfileString(_T("Setting"), _T("Y"), y, m_Ini);
 }
 
 void CDiskInfoDlg::OnGetMinMaxInfo(MINMAXINFO* lpMMI)

--- a/DiskInfoDlg.h
+++ b/DiskInfoDlg.h
@@ -283,6 +283,9 @@ protected:
 	void SetControlFont();
 	virtual void SetClientSize(int sizeX, int sizeY, double zoomRatio);
 
+	void SavePos() const;
+	void RestorePos();
+	
 	void UpdateShareInfo(); // For Sidebar Gadget Support
 	void DeleteShareInfo();
 

--- a/DiskInfoDlgInit.cpp
+++ b/DiskInfoDlgInit.cpp
@@ -187,6 +187,31 @@ BOOL CDiskInfoDlg::OnInitDialog()
 	return TRUE; 
 }
 
+void CDiskInfoDlg::RestorePos()
+{
+	const int x = GetPrivateProfileInt(_T("Setting"), _T("X"), INT_MIN, m_Ini);
+	const int y = GetPrivateProfileInt(_T("Setting"), _T("Y"), INT_MIN, m_Ini);
+
+	RECT rw, rc;
+	GetWindowRect(&rw);
+
+	rc.left = x;
+	rc.top = y;
+	rc.right = x + rw.right - rw.left;
+	rc.bottom = y + rw.bottom - rw.top;
+
+	HMONITOR hMonitor = MonitorFromRect(&rc, MONITOR_DEFAULTTONULL);
+	if (hMonitor == nullptr)
+	{
+		DebugPrint(_T("CenterWindow()"));
+		CenterWindow();
+	}
+	else
+	{
+		SetWindowPos(nullptr, x, y, 0, 0, SWP_NOSIZE | SWP_NOZORDER);
+	}
+}
+
 void CDiskInfoDlg::InitDialogComplete()
 {
 	DebugPrint(_T("InitDialogComplete"));
@@ -211,8 +236,8 @@ void CDiskInfoDlg::InitDialogComplete()
 		CheckPage();
 			
 		m_bShowWindow = TRUE;
-		DebugPrint(_T("CenterWindow()"));
-		CenterWindow();
+		DebugPrint(_T("RestorePos()"));
+		RestorePos();
 
 		if(m_bResident)
 		{


### PR DESCRIPTION
#73 Save Windows Position

* 終了時にウィンドウ位置 X, Y を保存
* 起動時、X, Y を使ったウィンドウ領域がいずれかのディスプレイ領域に入る場合は、ウィンドウ位置を復元。入らない場合は、これまで通り、CenterWindow(); を実行