### PR TITLE
Smart フォルダーの変更

### DIFF
--- a/DiskInfo.cpp
+++ b/DiskInfo.cpp
@@ -178,8 +178,23 @@ BOOL CDiskInfoApp::InitInstance()
 	m_ExeDir.Format(_T("%s\\"), tmp);
 	m_ThemeDir.Format(_T("%s\\%s"), tmp, THEME_DIR);
 	m_LangDir.Format(_T("%s\\%s"), tmp, LANGUAGE_DIR);
-	m_SmartDir.Format(_T("%s\\%s"), tmp, SMART_DIR);
 	m_GadgetDir.Format(_T("%s\\%s"), tmp, GADGET_DIR);
+
+	// Smart folder
+	TCHAR smartDir[256];
+	GetPrivateProfileString(_T("Setting"), _T("SmartDir"), _T(""), smartDir, 256, m_Ini);
+	if (CreateDirectory(smartDir, nullptr) || GetLastError() == ERROR_ALREADY_EXISTS) {
+		m_SmartDir.Format(_T("%s"), smartDir);
+		if (m_SmartDir.Right(1).Compare(_T("\\")) != 0) // Add "\"
+		{
+			m_SmartDir.Format(_T("%s\\"), smartDir);
+		}
+	}
+	else
+	{
+		// Default path
+		m_SmartDir.Format(_T("%s\\%s"), tmp, SMART_DIR);
+	}
 
 	if(IsDotNet4())
 	{

--- a/DiskInfo.cpp
+++ b/DiskInfo.cpp
@@ -183,7 +183,7 @@ BOOL CDiskInfoApp::InitInstance()
 	// Smart folder
 	TCHAR smartDir[256];
 	GetPrivateProfileString(_T("Setting"), _T("SmartDir"), _T(""), smartDir, 256, m_Ini);
-	if (CreateDirectory(smartDir, nullptr) || GetLastError() == ERROR_ALREADY_EXISTS) {
+	if (_tcscmp(smartDir, _T("")) != 0 || CreateDirectory(smartDir, nullptr) || GetLastError() == ERROR_ALREADY_EXISTS) {
 		m_SmartDir.Format(_T("%s"), smartDir);
 		if (m_SmartDir.Right(1).Compare(_T("\\")) != 0) // Add "\"
 		{


### PR DESCRIPTION
#64 Customize Smart folder 

ini ファイルに SmartDir でフォルダーパスが指定されている場合、その場所に Smart ログを保存する。
SmartDir 項目が無い場合、またはフォルダー作成がすでに存在する理由以外で失敗した場合は、デフォルトパスを使用（今までの動作と同じ）

#64 の要望の理由がニッチな感じなのでとりあえう直接 ini ファイルを編集した場合に実現できるところまで実装。