### PR TITLE
Add option to select random theme

### DIFF
--- a/DiskInfoDlg.cpp
+++ b/DiskInfoDlg.cpp
@@ -122,6 +122,7 @@ CDiskInfoDlg::CDiskInfoDlg(CWnd* pParent /*=NULL*/, BOOL flagStartupExit)
 	m_RecommendTheme = L"Default";
 	m_ThemeKeyName = L"Theme";
 #endif
+	m_RandomThemeLabel = L"Random";
 
 	m_BackgroundName = L"Background";
 

--- a/Priscilla/DialogFx.h
+++ b/Priscilla/DialogFx.h
@@ -129,6 +129,7 @@ protected:
 	CString m_DefaultTheme;
 	CString m_ParentTheme1;
 	CString m_ParentTheme2;
+	CString m_RandomThemeLabel;
 
 	// Language for SubClass
 	CString m_LangDir;

--- a/Priscilla/MainDialogFx.h
+++ b/Priscilla/MainDialogFx.h
@@ -42,6 +42,7 @@ protected:
 	BYTE GetControlAlpha(CString name, BYTE defaultAlpha, CString theme);
 	BYTE GetCharacterPosition(CString theme);
 	CString GetParentTheme(int i, CString theme);
+	CString GetRandomTheme();
 	void SaveImageDlg(CImage* image);
 
 	virtual BOOL OnInitDialog();


### PR DESCRIPTION
This change adds the menu item for "Random" as a selectable theme. When chosen,
a random theme will be chosen from the available themes. Tested on Standard,
Shizuku, and KureiKei builds.

Fixes #119 