### PR TITLE
[Workaround] adding spaces to ensure small tooltips is full display

### DIFF
--- a/DiskInfoDlgUpdate.cpp
+++ b/DiskInfoDlgUpdate.cpp
@@ -1265,11 +1265,11 @@ BOOL CDiskInfoDlg::ChangeDisk(DWORD i)
 
 		if(m_Ata.vars[i].HostReads > 1024 * 1024)
 		{
-			cstr.Format(_T("%.3f PB"), m_Ata.vars[i].HostReads / 1024.0 / 1024.0);
+			cstr.Format(_T("%.3f PB  "), m_Ata.vars[i].HostReads / 1024.0 / 1024.0);
 		}
 		else if(m_Ata.vars[i].HostReads > 1024)
 		{
-			cstr.Format(_T("%.3f TB"), m_Ata.vars[i].HostReads / 1024.0);
+			cstr.Format(_T("%.3f TB  "), m_Ata.vars[i].HostReads / 1024.0);
 		}
 
 		m_BufferSize.Format(_T("%d GB"), m_Ata.vars[i].HostReads);
@@ -1305,11 +1305,11 @@ BOOL CDiskInfoDlg::ChangeDisk(DWORD i)
 
 		if(m_Ata.vars[i].HostWrites > 1024 * 1024)
 		{
-			cstr.Format(_T("%.3f PB"), m_Ata.vars[i].HostWrites / 1024.0 / 1024.0);
+			cstr.Format(_T("%.3f PB  "), m_Ata.vars[i].HostWrites / 1024.0 / 1024.0);
 		}
 		else if(m_Ata.vars[i].HostWrites > 1024)
 		{
-			cstr.Format(_T("%.3f TB"), m_Ata.vars[i].HostWrites / 1024.0);
+			cstr.Format(_T("%.3f TB  "), m_Ata.vars[i].HostWrites / 1024.0);
 		}
 
 		m_NvCacheSize.Format(_T("%d GB"), m_Ata.vars[i].HostWrites);


### PR DESCRIPTION
At least on Win10 21H1, this control appear the automatic folding bug while narrow width.

Before:
![image](https://user-images.githubusercontent.com/1769875/136326889-ccef2787-5f36-4db0-aa99-17657eb6f8f8.png)
After:
![DiskInfo32D](https://user-images.githubusercontent.com/1769875/136326905-693df155-10c9-411e-9dec-7011fdb33935.png)
