### PR TITLE
some-issue-fix-C++23-ver2

### DIFF
--- a/AtaSmart.h
+++ b/AtaSmart.h
@@ -1727,114 +1727,114 @@ public:
 
 	struct ATA_SMART_INFO
 	{
-		IDENTIFY_DEVICE		IdentifyDevice;
-		BYTE				SmartReadData[512];
-		BYTE				SmartReadThreshold[512];
-		SMART_ATTRIBUTE		Attribute[MAX_ATTRIBUTE];
-		SMART_THRESHOLD		Threshold[MAX_ATTRIBUTE];
+		IDENTIFY_DEVICE		IdentifyDevice{};
+		BYTE				SmartReadData[512]{};
+		BYTE				SmartReadThreshold[512]{};
+		SMART_ATTRIBUTE		Attribute[MAX_ATTRIBUTE]{};
+		SMART_THRESHOLD		Threshold[MAX_ATTRIBUTE]{};
 
-		BOOL				IsSmartEnabled;
-		BOOL				IsIdInfoIncorrect;
-		BOOL				IsSmartCorrect;
-		BOOL				IsThresholdCorrect;
-		BOOL				IsCheckSumError;
-		BOOL				IsWord88;
-		BOOL				IsWord64_76;
-		BOOL				IsRawValues8;
-		BOOL				IsRawValues7;
-		BOOL				Is9126MB;
-		BOOL				IsThresholdBug;
+		BOOL				IsSmartEnabled{};
+		BOOL				IsIdInfoIncorrect{};
+		BOOL				IsSmartCorrect{};
+		BOOL				IsThresholdCorrect{};
+		BOOL				IsCheckSumError{};
+		BOOL				IsWord88{};
+		BOOL				IsWord64_76{};
+		BOOL				IsRawValues8{};
+		BOOL				IsRawValues7{};
+		BOOL				Is9126MB{};
+		BOOL				IsThresholdBug{};
 
-		BOOL				IsSmartSupported;
-		BOOL				IsLba48Supported;
-		BOOL				IsAamSupported;
-		BOOL				IsApmSupported;
-		BOOL				IsAamEnabled;
-		BOOL				IsApmEnabled;
-		BOOL				IsNcqSupported;
-		BOOL				IsNvCacheSupported;
-		BOOL				IsDeviceSleepSupported;
-		BOOL				IsMaxtorMinute;
-		BOOL				IsSsd;
-		BOOL				IsTrimSupported;
-		BOOL				IsVolatileWriteCachePresent;
+		BOOL				IsSmartSupported{};
+		BOOL				IsLba48Supported{};
+		BOOL				IsAamSupported{};
+		BOOL				IsApmSupported{};
+		BOOL				IsAamEnabled{};
+		BOOL				IsApmEnabled{};
+		BOOL				IsNcqSupported{};
+		BOOL				IsNvCacheSupported{};
+		BOOL				IsDeviceSleepSupported{};
+		BOOL				IsMaxtorMinute{};
+		BOOL				IsSsd{};
+		BOOL				IsTrimSupported{};
+		BOOL				IsVolatileWriteCachePresent{};
 
-		BOOL				IsNVMe;
-		BOOL				IsUasp;
+		BOOL				IsNVMe{};
+		BOOL				IsUasp{};
 
-		INT					PhysicalDriveId;
-		INT					ScsiPort;
-		INT					ScsiTargetId;
-		INT					ScsiBus;
-		INT					SiliconImageType;
+		INT					PhysicalDriveId{};
+		INT					ScsiPort{};
+		INT					ScsiTargetId{};
+		INT					ScsiBus{};
+		INT					SiliconImageType{};
 //		INT					AccessType;
 
-		DWORD				TotalDiskSize;
-		DWORD				Cylinder;
-		DWORD				Head;
-		DWORD				Sector;
-		DWORD				Sector28;
-		ULONGLONG			Sector48;
-		ULONGLONG			NumberOfSectors;
-		DWORD				DiskSizeChs;
-		DWORD				DiskSizeLba28;
-		DWORD				DiskSizeLba48;
-		DWORD				LogicalSectorSize;
-		DWORD				PhysicalSectorSize;
-		DWORD				DiskSizeWmi;
-		DWORD				BufferSize;
-		ULONGLONG			NvCacheSize;
-		DWORD				TransferModeType;
-		DWORD				DetectedTimeUnitType;
-		DWORD				MeasuredTimeUnitType;
-		DWORD				AttributeCount;
-		INT					DetectedPowerOnHours;
-		INT					MeasuredPowerOnHours;
-		INT					PowerOnRawValue;
-		INT					PowerOnStartRawValue;
-		DWORD				PowerOnCount;
-		INT					Temperature;
-		double				TemperatureMultiplier;
-		DWORD				NominalMediaRotationRate;
+		DWORD				TotalDiskSize{};
+		DWORD				Cylinder{};
+		DWORD				Head{};
+		DWORD				Sector{};
+		DWORD				Sector28{};
+		ULONGLONG			Sector48{};
+		ULONGLONG			NumberOfSectors{};
+		DWORD				DiskSizeChs{};
+		DWORD				DiskSizeLba28{};
+		DWORD				DiskSizeLba48{};
+		DWORD				LogicalSectorSize{};
+		DWORD				PhysicalSectorSize{};
+		DWORD				DiskSizeWmi{};
+		DWORD				BufferSize{};
+		ULONGLONG			NvCacheSize{};
+		DWORD				TransferModeType{};
+		DWORD				DetectedTimeUnitType{};
+		DWORD				MeasuredTimeUnitType{};
+		DWORD				AttributeCount{};
+		INT					DetectedPowerOnHours{};
+		INT					MeasuredPowerOnHours{};
+		INT					PowerOnRawValue{};
+		INT					PowerOnStartRawValue{};
+		DWORD				PowerOnCount{};
+		INT					Temperature{};
+		double				TemperatureMultiplier{};
+		DWORD				NominalMediaRotationRate{};
 //		double				Speed;
-		INT					HostWrites;
-		INT					HostReads;
-		INT					GBytesErased;
-		INT					NandWrites;
-		INT					WearLevelingCount;
+		INT					HostWrites{};
+		INT					HostReads{};
+		INT					GBytesErased{};
+		INT					NandWrites{};
+		INT					WearLevelingCount{};
 
 //		INT					PlextorNandWritesUnit;
 
-		INT					Life;
-		BOOL				FlagLifeRawValue;
-		BOOL				FlagLifeRawValueIncrement;
-		BOOL				FlagLifeSanDiskUsbMemory;
-		BOOL				FlagLifeSanDisk0_1;
-		BOOL				FlagLifeSanDisk1;
-		BOOL				FlagLifeSanDiskLenovo;
+		INT					Life{};
+		BOOL				FlagLifeRawValue{};
+		BOOL				FlagLifeRawValueIncrement{};
+		BOOL				FlagLifeSanDiskUsbMemory{};
+		BOOL				FlagLifeSanDisk0_1{};
+		BOOL				FlagLifeSanDisk1{};
+		BOOL				FlagLifeSanDiskLenovo{};
 
-		DWORD				Major;
-		DWORD				Minor;
+		DWORD				Major{};
+		DWORD				Minor{};
 
-		DWORD				DiskStatus;
-		DWORD				DriveLetterMap;
+		DWORD				DiskStatus{};
+		DWORD				DriveLetterMap{};
 		// 
-		INT 				AlarmTemperature;
-		BOOL				AlarmHealthStatus;
+		INT 				AlarmTemperature{};
+		BOOL				AlarmHealthStatus{};
 
 		INTERFACE_TYPE		InterfaceType;
 		COMMAND_TYPE		CommandType;
 		HOST_READS_WRITES_UNIT HostReadsWritesUnit;
 
-		DWORD				DiskVendorId;
-		DWORD				UsbVendorId;
-		DWORD				UsbProductId;
-		BYTE				Target;
+		DWORD				DiskVendorId{};
+		DWORD				UsbVendorId{};
+		DWORD				UsbProductId{};
+		BYTE				Target{};
 
-		WORD				Threshold05;
-		WORD				ThresholdC5;
-		WORD				ThresholdC6;
-		WORD				ThresholdFF;
+		WORD				Threshold05{};
+		WORD				ThresholdC5{};
+		WORD				ThresholdC6{};
+		WORD				ThresholdFF{};
 
 		CSMI_SAS_PHY_ENTITY sasPhyEntity;
 
@@ -1864,8 +1864,8 @@ public:
 	struct EXTERNAL_DISK_INFO
 	{
 		CString Enclosure;
-		DWORD	UsbVendorId;
-		DWORD	UsbProductId;
+		DWORD	UsbVendorId{};
+		DWORD	UsbProductId{};
 	};
 
 	CArray<ATA_SMART_INFO, ATA_SMART_INFO> vars;
@@ -1934,7 +1934,7 @@ protected:
 //	VOID InitStruct();
 	VOID ChangeByteOrder(PCHAR str, DWORD length);
 	BOOL CheckAsciiStringError(PCHAR str, DWORD length);
-	HANDLE GetIoCtrlHandle(BYTE index);
+	HANDLE GetIoCtrlHandle(INT/*BYTE*/ index);
 	HANDLE GetIoCtrlHandle(INT scsiPort, DWORD siliconImageType);
 	HANDLE GetIoCtrlHandleCsmi(INT scsiPort);
 	HANDLE GetIoCtrlHandleMegaRAID(INT scsiPort);

--- a/DHtmlDialogEx.cpp
+++ b/DHtmlDialogEx.cpp
@@ -22,6 +22,8 @@ CDHtmlDialogEx::CDHtmlDialogEx(UINT dlgResouce, UINT dlgHtml, CWnd* pParent)
 	m_ParentWnd = NULL;
 	m_DlgWnd = NULL;
 	m_MenuId = 0;
+	m_hAccelerator = NULL;
+	m_Ini[0] = '\0';
 
 	m_ZoomRatio = 1.0;
 	m_ZoomType = ZoomTypeAuto;
@@ -121,8 +123,8 @@ void CDHtmlDialogEx::EnableDpiAware()
 {
 	if(GetIeVersion() >= 800)
 	{
-		DOCHOSTUIINFO info;
-		info.cbSize = sizeof(info);
+		DOCHOSTUIINFO info = { sizeof(info) };
+		//info.cbSize = sizeof(info);
 		GetHostInfo(&info);
 		SetHostFlags(info.dwFlags | DOCHOSTUIFLAG_DIALOG | DOCHOSTUIFLAG_THEME | DOCHOSTUIFLAG_DPI_AWARE);
 	}
@@ -178,8 +180,8 @@ DWORD CDHtmlDialogEx::ChangeZoomType(DWORD zoomType)
 void CDHtmlDialogEx::InitDialogEx(DWORD sizeX, DWORD sizeY, CString dialogPath)
 {
 // Enabled Visual Style
-	DOCHOSTUIINFO info;
-	info.cbSize = sizeof(info);
+	DOCHOSTUIINFO info = { sizeof(info) };
+	//info.cbSize = sizeof(info);
 	GetHostInfo(&info);
 	SetHostFlags(info.dwFlags | DOCHOSTUIFLAG_DIALOG | DOCHOSTUIFLAG_THEME);
 
@@ -202,7 +204,7 @@ void CDHtmlDialogEx::InitDialogEx(DWORD sizeX, DWORD sizeY, CString dialogPath)
 // 2008/1/19 //
 void CDHtmlDialogEx::SetClientRect(DWORD sizeX, DWORD sizeY, DWORD menuLine)
 {
-	RECT rc;
+	RECT rc{};
 	RECT clientRc;
 	rc.left = 0;
 	rc.top = 0;
@@ -422,21 +424,22 @@ CString CDHtmlDialogEx::i18n(CString section, CString key, BOOL inEnglish)
 
 STDMETHODIMP CDHtmlDialogEx::GetOptionKeyPath(LPOLESTR *pchKey, DWORD dw)
 {
-    HRESULT hr;
-    WCHAR* szKey = L"Software";
+	HRESULT hr{};
+    WCHAR szKey[] = L"Software";
 	
-    size_t cbLength;
+	size_t cbLength{};
     hr = StringCbLengthW(szKey, 1280, &cbLength);
     //  TODO: Add error handling code here.
-    
-    if (pchKey)
-    {
-        *pchKey = (LPOLESTR)CoTaskMemAlloc(cbLength + sizeof(WCHAR));
-        if (*pchKey)
-            hr = StringCbCopyW(*pchKey, cbLength + sizeof(WCHAR), szKey);
-    }
-    else
-        hr = E_INVALIDARG;
+	if (SUCCEEDED(hr)) {
+		if (pchKey)
+		{
+			*pchKey = (LPOLESTR)CoTaskMemAlloc(cbLength + sizeof(WCHAR));
+				if (*pchKey)
+					hr = StringCbCopyW(*pchKey, cbLength + sizeof(WCHAR), szKey);
+		}
+		else
+			hr = E_INVALIDARG;
+	}
 
     return hr;
 }

--- a/DHtmlMainDialog.cpp
+++ b/DHtmlMainDialog.cpp
@@ -43,11 +43,11 @@ void CDHtmlMainDialog::SetWindowTitle(CString message, CString mode)
 
 	if(! message.IsEmpty())
 	{
-		title.Format(_T("%s - %s"), PRODUCT_SHORT_NAME, message);
+		title.Format(_T("%s - %s"), PRODUCT_SHORT_NAME, message.GetString());
 	}
 	else if(! mode.IsEmpty())
 	{
-		title.Format(_T("%s %s %s"), PRODUCT_NAME, PRODUCT_VERSION, mode);
+		title.Format(_T("%s %s %s"), PRODUCT_NAME, PRODUCT_VERSION, mode.GetString());
 	}
 	else
 	{
@@ -86,20 +86,20 @@ void CDHtmlMainDialog::InitThemeLang()
 // Set Language
 	GetPrivateProfileString(_T("Setting"), _T("Language"), _T(""), str, 256, m_Ini);
 
-	langPath.Format(_T("%s\\%s.lang"), m_LangDir, str);
-	m_DefaultLangPath.Format(_T("%s\\%s.lang"), m_LangDir, _T("English"));
+	langPath.Format(_T("%s\\%s.lang"), m_LangDir.GetString(), str);
+	m_DefaultLangPath.Format(_T("%s\\%s.lang"), m_LangDir.GetString(), _T("English"));
 
 	if(_tcscmp(str, _T("")) != 0 && IsFileExist((const TCHAR*)langPath))
 	{
 		m_CurrentLang = str;
-		m_CurrentLangPath.Format(_T("%s\\%s.lang"), m_LangDir, str);
+		m_CurrentLangPath.Format(_T("%s\\%s.lang"), m_LangDir.GetString(), str);
 	}
 	else
 	{
 		m_CurrentLocalID.Format(_T("0x%04X"), GetUserDefaultLCID());
 		PrimaryLangID = PRIMARYLANGID(GetUserDefaultLCID());
 
-		langPath.Format(_T("%s\\*.lang"), m_LangDir);
+		langPath.Format(_T("%s\\*.lang"), m_LangDir.GetString());
 
 		hFind = ::FindFirstFile(langPath, &findData);
 		if(hFind != INVALID_HANDLE_VALUE)
@@ -109,14 +109,14 @@ void CDHtmlMainDialog::InitThemeLang()
 				{
 					i++;
 					CString cstr;
-					cstr.Format(_T("%s\\%s"), m_LangDir, findData.cFileName);
+					cstr.Format(_T("%s\\%s"), m_LangDir.GetString(), findData.cFileName);
 					GetPrivateProfileString(_T("Language"), _T("LOCALE_ID"), _T(""), str, 256, cstr);
 					if((ptrEnd = _tcsrchr(findData.cFileName, '.')) != NULL){*ptrEnd = '\0';}
 
 					if(_tcsstr(str, m_CurrentLocalID) != NULL)
 					{
 						m_CurrentLang = findData.cFileName;
-						m_CurrentLangPath.Format(_T("%s\\%s.lang"), m_LangDir, findData.cFileName);
+						m_CurrentLangPath.Format(_T("%s\\%s.lang"), m_LangDir.GetString(), findData.cFileName);
 					}
 					if(PrimaryLangID == PRIMARYLANGID(_tcstol(str, NULL, 16)))
 					{
@@ -132,12 +132,12 @@ void CDHtmlMainDialog::InitThemeLang()
 			if(PrimaryLang.IsEmpty())
 			{
 				m_CurrentLang = _T("English");
-				m_CurrentLangPath.Format(_T("%s\\%s.lang"), m_LangDir, m_CurrentLang);
+				m_CurrentLangPath.Format(_T("%s\\%s.lang"), m_LangDir.GetString(), m_CurrentLang.GetString());
 			}
 			else
 			{
 				m_CurrentLang = PrimaryLang;
-				m_CurrentLangPath.Format(_T("%s\\%s.lang"), m_LangDir, PrimaryLang);
+				m_CurrentLangPath.Format(_T("%s\\%s.lang"), m_LangDir.GetString(), PrimaryLang.GetString());
 			}	
 		}
 	}
@@ -152,7 +152,7 @@ void CDHtmlMainDialog::InitMenu()
 	UINT newItemID = 0;
 	UINT currentItemID = 0;
 	UINT defaultStyleItemID = 0;
-	UINT defaultLanguageItemID = 0;
+	//UINT defaultLanguageItemID = 0;
 	WIN32_FIND_DATA findData;
 	WIN32_FIND_DATA findCssData;
 	HANDLE hFind;
@@ -168,7 +168,7 @@ void CDHtmlMainDialog::InitMenu()
 	subMenu.Attach(menu.GetSubMenu(m_ThemeIndex)->GetSafeHmenu());
 //	subMenu.RemoveMenu(0, MF_BYPOSITION);
 
-	themePath.Format(_T("%s\\*.*"), m_ThemeDir);
+	themePath.Format(_T("%s\\*.*"), m_ThemeDir.GetString());
 
 	hFind = ::FindFirstFile(themePath, &findData);
 	if(hFind != INVALID_HANDLE_VALUE)
@@ -224,7 +224,7 @@ void CDHtmlMainDialog::InitMenu()
 	subMenuOZ.Attach(subMenu.GetSubMenu(1)->GetSafeHmenu()); // 2nd is "O~Z"
 	subMenuOZ.RemoveMenu(0, MF_BYPOSITION);
 
-	langPath.Format(_T("%s\\*.lang"), m_LangDir);
+	langPath.Format(_T("%s\\*.lang"), m_LangDir.GetString());
 	i = 0;
 	hFind = ::FindFirstFile(langPath, &findData);
 	if(hFind != INVALID_HANDLE_VALUE)
@@ -237,7 +237,7 @@ void CDHtmlMainDialog::InitMenu()
 
 				// Add Language
 				CString cstr;
-				cstr.Format(_T("%s\\%s"), m_LangDir, findData.cFileName);
+				cstr.Format(_T("%s\\%s"), m_LangDir.GetString(), findData.cFileName);
 				GetPrivateProfileString(_T("Language"), _T("LANGUAGE"), _T(""), str, 256, cstr);
 				if((ptrEnd = _tcsrchr(findData.cFileName, '.')) != NULL)
 				{
@@ -367,7 +367,7 @@ void CDHtmlMainDialog::ChangeTheme(CString ThemeName)
 	hr = dispatch.pdispVal->QueryInterface(IID_IHTMLStyleSheet, (void **) &pHtmlStyleSheet);
 	if(FAILED(hr)) return ;
 
-	cstr.Format(_T("%s\\%s\\%s"), m_ThemeDir, ThemeName, MAIN_CSS_FILE_NAME);
+	cstr.Format(_T("%s\\%s\\%s"), m_ThemeDir.GetString(), ThemeName.GetString(), MAIN_CSS_FILE_NAME);
 	bstr = cstr;
 	hr = pHtmlStyleSheet->put_href(bstr);
 	if(FAILED(hr)) return ;
@@ -377,12 +377,12 @@ void CDHtmlMainDialog::ChangeTheme(CString ThemeName)
 
 #ifdef SUISHO_SHIZUKU_SUPPORT
 	#ifdef KUREI_KEI_SUPPORT
-		WritePrivateProfileString(_T("Setting"), _T("ThemeKureiKei"), ThemeName, m_Ini);
+		WritePrivateProfileString(_T("Setting"), _T("ThemeKureiKei"), ThemeName.GetString(), m_Ini);
 	#else
-		WritePrivateProfileString(_T("Setting"), _T("ThemeShizuku"), ThemeName, m_Ini);
+		WritePrivateProfileString(_T("Setting"), _T("ThemeShizuku"), ThemeName.GetString(), m_Ini);
 	#endif
 #else
-	WritePrivateProfileString(_T("Setting"), _T("Theme"), ThemeName, m_Ini);
+	WritePrivateProfileString(_T("Setting"), _T("Theme"), ThemeName.GetString(), m_Ini);
 #endif
 
 
@@ -392,7 +392,7 @@ void CDHtmlMainDialog::ChangeTheme(CString ThemeName)
 BOOL CDHtmlMainDialog::OnCommand(WPARAM wParam, LPARAM lParam) 
 {
 	// Select Theme
-	if(WM_THEME_ID <= wParam && wParam < WM_THEME_ID + (UINT)m_MenuArrayTheme.GetSize())
+	if(WM_THEME_ID <= wParam && wParam < WM_THEME_ID + (WPARAM)m_MenuArrayTheme.GetSize())
 	{
 		CMenu menu;
 		CMenu subMenu;

--- a/DiskInfo.cpp
+++ b/DiskInfo.cpp
@@ -61,8 +61,8 @@ BOOL CDiskInfoApp::InitInstance()
 	int defaultDisk = -1;
 	HANDLE hMutex = NULL;
 
-	INITCOMMONCONTROLSEX InitCtrls;
-	InitCtrls.dwSize = sizeof(InitCtrls);
+	INITCOMMONCONTROLSEX InitCtrls = { sizeof(INITCOMMONCONTROLSEX) };
+	//InitCtrls.dwSize = sizeof(InitCtrls);
 	InitCtrls.dwICC = ICC_WIN95_CLASSES;
 	InitCommonControlsEx(&InitCtrls);
 	CWinApp::InitInstance();
@@ -104,7 +104,7 @@ BOOL CDiskInfoApp::InitInstance()
 	WritePrivateProfileString(_T("Setting"), _T("DebugMode"), cstr, m_Ini);
 
 	int argc = 0;
-	int index = 0;
+	//int index = 0;
 	LPWSTR *argv = CommandLineToArgvW(GetCommandLineW(), &argc);
 
 	if(argc > 1)
@@ -226,10 +226,10 @@ BOOL CDiskInfoApp::InitInstance()
 	m_ThemeIndex = MENU_THEME_INDEX;
 	m_LangIndex = MENU_LANG_INDEX;
 
-	DefaultTheme.Format(_T("%s\\%s"), m_ThemeDir, DEFAULT_THEME);
-	DefaultLanguage.Format(_T("%s\\%s.lang"), m_LangDir, DEFAULT_LANGUAGE);
+	DefaultTheme.Format(_T("%s\\%s"), m_ThemeDir.GetString(), DEFAULT_THEME);
+	DefaultLanguage.Format(_T("%s\\%s.lang"), m_LangDir.GetString(), DEFAULT_LANGUAGE);
 
-	OSVERSIONINFOEX osvi;
+	/*OSVERSIONINFOEX osvi;
 	BOOL bosVersionInfoEx;
 
 	ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
@@ -238,7 +238,7 @@ BOOL CDiskInfoApp::InitInstance()
 	{
 		osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
 		GetVersionEx((OSVERSIONINFO *)&osvi);
-	}
+	}*/
 
 	if((BOOL)GetPrivateProfileInt(_T("Workaround"), _T("IE8MODE"), 0, m_Ini))
 	{
@@ -261,7 +261,7 @@ BOOL CDiskInfoApp::InitInstance()
 #ifdef _UNICODE
 	if(! IsUserAnAdmin())
 	{
-		if(osvi.dwMajorVersion < 6)
+		if( ! UtilityFx__IsWindowsVersionOrGreater( 6, 0 )/*osvi.dwMajorVersion < 6*/)
 		{
 			AfxMessageBox(_T("CrystalDiskInfo is required Administrator Privileges."));
 		}
@@ -276,7 +276,7 @@ BOOL CDiskInfoApp::InitInstance()
 	{
 		CGraphDlg dlg(NULL, defaultDisk);
 		m_pMainWnd = &dlg;
-		INT_PTR nResponse = dlg.DoModal();
+		/*INT_PTR nResponse = */(void)dlg.DoModal();
 	}
 	else
 	{
@@ -296,7 +296,7 @@ BOOL CDiskInfoApp::InitInstance()
 		else
 		{
 			DebugPrint(_T("CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);"));
-			CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
+			(void)CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
 		}
 
 		CDiskInfoDlg dlg(NULL, flagStartupExit);

--- a/DiskInfo.h
+++ b/DiskInfo.h
@@ -62,12 +62,12 @@ public:
 	CString m_Ini;
 	CString m_Txt;
 	CString m_SaveAsText;
-	BOOL m_bCopyExit;
+	BOOL m_bCopyExit{};
 
 	CString m_ThemeDir;
 	CString m_LangDir;
-	DWORD m_ThemeIndex;
-	DWORD m_LangIndex;
+	DWORD m_ThemeIndex{};
+	DWORD m_LangIndex{};
 
 // Overrides
 	public:

--- a/DiskInfoDlg.cpp
+++ b/DiskInfoDlg.cpp
@@ -333,7 +333,7 @@ BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam);
 
 void CDiskInfoDlg::KillGraphDlg()
 {
-	static HWND hWnd;
+	//static HWND hWnd{};
 	EnumWindows(EnumWindowsProc, (LPARAM)&m_GraphProcessId);
 }
 
@@ -816,7 +816,7 @@ HCURSOR CDiskInfoDlg::OnQueryDragIcon()
 
 BOOL CDiskInfoDlg::OnCommand(WPARAM wParam, LPARAM lParam) 
 {
-	if(WM_LANGUAGE_ID <= wParam && wParam < WM_LANGUAGE_ID + (UINT)m_MenuArrayLang.GetSize())
+	if(WM_LANGUAGE_ID <= wParam && wParam < (WPARAM)WM_LANGUAGE_ID + m_MenuArrayLang.GetSize())
 	{
 #ifdef _UNICODE
 		CMenu menu;
@@ -891,15 +891,15 @@ BOOL CDiskInfoDlg::OnCommand(WPARAM wParam, LPARAM lParam)
 	{
 		ShowTemperatureIconOnly();
 	}
-	else if(wParam == SHOW_GRAPH_BASE + CAtaSmart::MAX_DISK)
+	else if(wParam == (WPARAM)SHOW_GRAPH_BASE + CAtaSmart::MAX_DISK)
 	{
 		ShowGraphDlg(-1); // Using "GraphHideDisk" option
 	}
-	else if(SHOW_GRAPH_BASE <= wParam && wParam < SHOW_GRAPH_BASE + CAtaSmart::MAX_DISK)
+	else if(SHOW_GRAPH_BASE <= wParam && wParam < (WPARAM)SHOW_GRAPH_BASE + CAtaSmart::MAX_DISK)
 	{
 		ShowGraphDlg((int)wParam - SHOW_GRAPH_BASE);
 	}
-	else if(ALARM_SETTING_HEALTH_STATUS_BASE <= wParam && wParam <= ALARM_SETTING_HEALTH_STATUS_BASE + CAtaSmart::MAX_DISK + 1)
+	else if(ALARM_SETTING_HEALTH_STATUS_BASE <= wParam && wParam <= (WPARAM)ALARM_SETTING_HEALTH_STATUS_BASE + CAtaSmart::MAX_DISK + 1)
 	{
 		int i = (int)(wParam - ALARM_SETTING_HEALTH_STATUS_BASE);
 
@@ -935,7 +935,7 @@ BOOL CDiskInfoDlg::OnCommand(WPARAM wParam, LPARAM lParam)
 			WritePrivateProfileStringFx(_T("AlarmHealthStatus"), m_Ata.vars[i].ModelSerial, alarm, m_Ini);
 		}
 	}
-	else if(ALARM_SETTING_TEMPERATURE_BASE <= wParam && wParam <= ALARM_SETTING_TEMPERATURE_BASE + (CAtaSmart::MAX_DISK + 1) * 100)
+	else if(ALARM_SETTING_TEMPERATURE_BASE <= wParam && wParam <= (WPARAM)ALARM_SETTING_TEMPERATURE_BASE + ((WPARAM)CAtaSmart::MAX_DISK + 1) * 100)
 	{
 		int i = (int)(wParam - ALARM_SETTING_TEMPERATURE_BASE) / 100;
 		int j = (int)(wParam - ALARM_SETTING_TEMPERATURE_BASE) % 100;
@@ -958,7 +958,7 @@ BOOL CDiskInfoDlg::OnCommand(WPARAM wParam, LPARAM lParam)
 			WritePrivateProfileStringFx(_T("AlarmTemperature"), m_Ata.vars[i].ModelSerial, temperature, m_Ini);
 		}
 	}
-	else if(TRAY_TEMPERATURE_ICON_BASE <= wParam && wParam <= TRAY_TEMPERATURE_ICON_BASE + CAtaSmart::MAX_DISK + 1)
+	else if(TRAY_TEMPERATURE_ICON_BASE <= wParam && wParam <= (WPARAM)TRAY_TEMPERATURE_ICON_BASE + CAtaSmart::MAX_DISK + 1)
 	{
 		int i = (int)(wParam - TRAY_TEMPERATURE_ICON_BASE);
 
@@ -1041,13 +1041,13 @@ BOOL CDiskInfoDlg::OnCommand(WPARAM wParam, LPARAM lParam)
 			}
 		}
 	}
-	else if(SELECT_DISK_BASE <= wParam && wParam < SELECT_DISK_BASE + CAtaSmart::MAX_DISK)
+	else if(SELECT_DISK_BASE <= wParam && wParam < (WPARAM)SELECT_DISK_BASE + CAtaSmart::MAX_DISK)
 	{
 		int i = (int)(wParam - SELECT_DISK_BASE);
 		m_DriveMenuPage = i / 8;
 		SelectDrive(i);
 	}
-	else if(AUTO_REFRESH_TARGET_BASE <= wParam && wParam <= AUTO_REFRESH_TARGET_BASE + CAtaSmart::MAX_DISK + 1)
+	else if(AUTO_REFRESH_TARGET_BASE <= wParam && wParam <= (WPARAM)AUTO_REFRESH_TARGET_BASE + CAtaSmart::MAX_DISK + 1)
 	{
 		int i = (int)(wParam - AUTO_REFRESH_TARGET_BASE);
 		// Target All Disk : AUTO_REFRESH_TARGET_BASE + CAtaSmart::MAX_DISK
@@ -1089,7 +1089,7 @@ BOOL CDiskInfoDlg::OnCommand(WPARAM wParam, LPARAM lParam)
 		SetMenu(menu);
 		DrawMenuBar();
 	}
-	else if(WM_THEME_ID <= wParam && wParam < WM_THEME_ID + (UINT)m_MenuArrayTheme.GetSize())
+	else if(WM_THEME_ID <= wParam && wParam < (WPARAM)WM_THEME_ID + m_MenuArrayTheme.GetSize())
 	{
 #ifndef SUISHO_SHIZUKU_SUPPORT
 		CMenu *menu = GetMenu();
@@ -1446,7 +1446,7 @@ void CDiskInfoDlg::OnSize(UINT nType, int cx, int cy)
 		// m_CtrlCopyright.MoveWindow(0, (int)(cy - (24 * m_ZoomRatio)), (int)(m_OffsetX * m_ZoomRatio), (int)(24 * m_ZoomRatio));
 		m_CtrlCopyright.InitControl((int)(positionX * m_ZoomRatio), (int)(cy - (24 * m_ZoomRatio)), (int)(OFFSET_X * m_ZoomRatio), (int)(24 * m_ZoomRatio), 1.0, &m_BkDC, IP(PROJECT_COPYRIGHT), 1, BS_CENTER, OwnerDrawImage, FALSE, FALSE, FALSE);
 #else
-		m_List.MoveWindow((int)((8 + m_OffsetX) * m_ZoomRatio), (int)(SIZE_Y * m_ZoomRatio), (int)((672 - 16) * m_ZoomRatio), (int)(cy - ((SIZE_Y + 8) * m_ZoomRatio)));
+		m_List.MoveWindow((int)((8.0 + m_OffsetX) * m_ZoomRatio), (int)(SIZE_Y * m_ZoomRatio), (int)((672.0 - 16.0) * m_ZoomRatio), (int)(cy - ((SIZE_Y + 8.0) * m_ZoomRatio)));
 #endif
 	}
 	flag = TRUE;
@@ -1482,8 +1482,8 @@ void CDiskInfoDlg::SetClientSize(int sizeX, int sizeY, double zoomRatio)
 
 void CDiskInfoDlg::SavePos() const
 {
-	WINDOWPLACEMENT place;
-	place.length = sizeof(WINDOWPLACEMENT);
+	WINDOWPLACEMENT place = { sizeof(WINDOWPLACEMENT) };
+	//place.length = sizeof(WINDOWPLACEMENT);
 	GetWindowPlacement(&place);
 
 	CString x, y;
@@ -1511,8 +1511,8 @@ void CDiskInfoDlg::AlarmHealthStatus(DWORD i, CString dir, CString disk)
 	DWORD niifType = NIIF_INFO;
 	int pre = -1;
 	
-	name.Format(_T("(%d) %s / %s / %s\r\n"), i + 1, m_Ata.vars[i].Model, m_Ata.vars[i].SerialNumber, m_Ata.vars[i].DriveMap);
-	title.Format(_T("(%d) %s / %s / %s"), i + 1, m_Ata.vars[i].Model, m_Ata.vars[i].SerialNumber, m_Ata.vars[i].DriveMap);
+	name.Format(_T("(%d) %s / %s / %s\r\n"), i + 1, m_Ata.vars[i].Model.GetString(), m_Ata.vars[i].SerialNumber.GetString(), m_Ata.vars[i].DriveMap.GetString());
+	title.Format(_T("(%d) %s / %s / %s"), i + 1, m_Ata.vars[i].Model.GetString(), m_Ata.vars[i].SerialNumber.GetString(), m_Ata.vars[i].DriveMap.GetString());
 
 	GetPrivateProfileString(disk, _T("HealthStatus"), _T("0"), str, 256, dir + _T("\\") + SMART_INI);
 	pre = _tstoi(str);
@@ -1523,8 +1523,8 @@ void CDiskInfoDlg::AlarmHealthStatus(DWORD i, CString dir, CString disk)
 	}
 	else if(m_Ata.vars[i].DiskStatus > (DWORD)pre && m_Ata.vars[i].DiskStatus != m_Ata.DISK_STATUS_GOOD)
 	{
-		cstr.Format(_T("%s: [%s] -> [%s]\r\n"), i18n(_T("Dialog"), _T("HEALTH_STATUS")),
-					GetDiskStatus(pre), GetDiskStatus(m_Ata.vars[i].DiskStatus));
+		cstr.Format(_T("%s: [%s] -> [%s]\r\n"), i18n(_T("Dialog"), _T("HEALTH_STATUS")).GetString(),
+					GetDiskStatus(pre).GetString(), GetDiskStatus(m_Ata.vars[i].DiskStatus).GetString());
 		alarm += cstr;
 		niifType = NIIF_WARNING;
 		AddEventLog(601, 2, name + cstr);
@@ -1534,8 +1534,8 @@ void CDiskInfoDlg::AlarmHealthStatus(DWORD i, CString dir, CString disk)
 	}
 	else if(m_Ata.vars[i].DiskStatus < (DWORD)pre)
 	{
-		cstr.Format(_T("%s: [%s] -> [%s]\r\n"), i18n(_T("Dialog"), _T("HEALTH_STATUS")),
-					GetDiskStatus(pre), GetDiskStatus(m_Ata.vars[i].DiskStatus));
+		cstr.Format(_T("%s: [%s] -> [%s]\r\n"), i18n(_T("Dialog"), _T("HEALTH_STATUS")).GetString(),
+					GetDiskStatus(pre).GetString(), GetDiskStatus(m_Ata.vars[i].DiskStatus).GetString());
 		alarm += cstr;
 		niifType = NIIF_INFO;
 		AddEventLog(701, 4, name + cstr);
@@ -1554,7 +1554,7 @@ void CDiskInfoDlg::AlarmHealthStatus(DWORD i, CString dir, CString disk)
 	}
 	else if(m_Ata.vars[i].Life < pre)
 	{
-		cstr.Format(_T("%s: [%d] -> [%d]\r\n"), i18n(_T("SmartSsd"), _T("FF")), pre, m_Ata.vars[i].Life);
+		cstr.Format(_T("%s: [%d] -> [%d]\r\n"), i18n(_T("SmartSsd"), _T("FF")).GetString(), pre, m_Ata.vars[i].Life);
 		alarm += cstr;
 		niifType = NIIF_WARNING;
 		AddEventLog(607, 2, name + cstr);
@@ -1564,7 +1564,7 @@ void CDiskInfoDlg::AlarmHealthStatus(DWORD i, CString dir, CString disk)
 	}
 	else if(m_Ata.vars[i].Life > pre)
 	{
-		cstr.Format(_T("%s: [%d] -> [%d]\r\n"), i18n(_T("SmartSsd"), _T("FF")), pre, m_Ata.vars[i].Life);
+		cstr.Format(_T("%s: [%d] -> [%d]\r\n"), i18n(_T("SmartSsd"), _T("FF")).GetString(), pre, m_Ata.vars[i].Life);
 		alarm += cstr;
 		niifType = NIIF_INFO;
 		AddEventLog(707, 4, name + cstr);
@@ -1610,8 +1610,8 @@ void CDiskInfoDlg::AlarmHealthStatus(DWORD i, CString dir, CString disk)
 			int rawValue = MAKEWORD(m_Ata.vars[i].Attribute[j].RawValue[0], m_Ata.vars[i].Attribute[j].RawValue[1]);
 			if(rawValue > pre && pre != -1)
 			{
-				cstr.Format(_T("%s: (%02X) %s [%d->%d]\r\n"), i18n(_T("Alarm"), _T("DEGRADATION")),
-					m_Ata.vars[i].Attribute[j].Id, i18n(_T("Smart"), id), pre, rawValue);
+				cstr.Format(_T("%s: (%02X) %s [%d->%d]\r\n"), i18n(_T("Alarm"), _T("DEGRADATION")).GetString(),
+					m_Ata.vars[i].Attribute[j].Id, i18n(_T("Smart"), id).GetString(), pre, rawValue);
 				alarm += cstr;
 				niifType = NIIF_WARNING;
 				AddEventLog(eventId, 2, name + cstr);
@@ -1621,8 +1621,8 @@ void CDiskInfoDlg::AlarmHealthStatus(DWORD i, CString dir, CString disk)
 			}
 			else if(rawValue < pre && pre != -1)
 			{
-				cstr.Format(_T("%s: (%02X) %s [%d->%d]\r\n"), i18n(_T("Alarm"), _T("RECOVERY")),
-					m_Ata.vars[i].Attribute[j].Id, i18n(_T("Smart"), id), pre, rawValue);
+				cstr.Format(_T("%s: (%02X) %s [%d->%d]\r\n"), i18n(_T("Alarm"), _T("RECOVERY")).GetString(),
+					m_Ata.vars[i].Attribute[j].Id, i18n(_T("Smart"), id).GetString(), pre, rawValue);
 				alarm += cstr;
 				niifType = NIIF_INFO;
 				AddEventLog(eventId + 100, 4, name + cstr);
@@ -1639,11 +1639,11 @@ void CDiskInfoDlg::AlarmHealthStatus(DWORD i, CString dir, CString disk)
 			{
 				if(m_bFahrenheit)
 				{
-					cstr.Format(_T("%s: %d F\r\n"), i18n(_T("Alarm"), _T("ALARM_TEMPERATURE")), m_Ata.vars[i].Temperature * 9 / 5 + 32);
+					cstr.Format(_T("%s: %d F\r\n"), i18n(_T("Alarm"), _T("ALARM_TEMPERATURE")).GetString(), m_Ata.vars[i].Temperature * 9 / 5 + 32);
 				}
 				else
 				{
-					cstr.Format(_T("%s: %d C\r\n"), i18n(_T("Alarm"), _T("ALARM_TEMPERATURE")), m_Ata.vars[i].Temperature);
+					cstr.Format(_T("%s: %d C\r\n"), i18n(_T("Alarm"), _T("ALARM_TEMPERATURE")).GetString(), m_Ata.vars[i].Temperature);
 				}
 				AddEventLog(606, 2, name + cstr);
 				SendMail(606, title, cstr);
@@ -1658,7 +1658,7 @@ void CDiskInfoDlg::AlarmHealthStatus(DWORD i, CString dir, CString disk)
 
 	if(! alarm.IsEmpty())
 	{
-		cstr.Format(_T("(%d) %s\n"), i + 1, m_Ata.vars[i].Model);
+		cstr.Format(_T("(%d) %s\n"), i + 1, m_Ata.vars[i].Model.GetString());
 		if(niifType == NIIF_WARNING)
 		{
 			ShowBalloon(m_MainIconId, niifType, i18n(_T("Alarm"), _T("ALARM_HEALTH_STATUS")), cstr + alarm);
@@ -1693,10 +1693,10 @@ BOOL CDiskInfoDlg::SendMail(DWORD eventId, CString title, CString message)
 
 	CString subject, body, option;
 
-	subject.Format(_T("[CDI] %s %s [%d]"), computer, title, eventId);
-	body.Format(_T("%s %s\r\n[%d] %s"), computer, title, eventId, message);
+	subject.Format(_T("[CDI] %s %s [%d]"), computer, title.GetString(), eventId);
+	body.Format(_T("%s %s\r\n[%d] %s"), computer, title.GetString(), eventId, message.GetString());
 
-	option.Format(_T("Subject=\"%s\" Body=\"%s\""), subject, body);
+	option.Format(_T("Subject=\"%s\" Body=\"%s\""), subject.GetString(), body.GetString());
 	if((INT_PTR)(ShellExecute(NULL, NULL, m_AlertMailPath, option, NULL, SW_SHOW)) > 32)
 	{
 		return TRUE;
@@ -1710,7 +1710,7 @@ BOOL CDiskInfoDlg::SendMail(DWORD eventId, CString title, CString message)
 BOOL CDiskInfoDlg::AddAlarmHistory(DWORD eventId, CString disk, CString message)
 {
 	CString cstr;
-	cstr.Format(L"[Alarm] EventID=%d, Disk=%s, Message=%s", eventId, disk, message);
+	cstr.Format(L"[Alarm] EventID=%d, Disk=%s, Message=%s", eventId, disk.GetString(), message.GetString());
 	cstr.Replace(L"\n", L"");
 	DebugPrint(cstr);
 	return FALSE;
@@ -1850,7 +1850,15 @@ BOOL CDiskInfoDlg::AlertSound(DWORD eventId, DWORD mode) const
 			return FALSE;
 		}
 		const HGLOBAL hOpus = LoadResource(hModule, hrs);
+		if (!hOpus)
+		{
+			return FALSE;
+		}
 		const LPBYTE lpOpus = static_cast<LPBYTE>(LockResource(hOpus));
+		if (!lpOpus)
+		{
+			return FALSE;
+		}
 		DWORD dwWrite = 0;
 
 		const HANDLE hFile = CreateFile(m_TempFilePathOpus, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_HIDDEN, nullptr);
@@ -1964,11 +1972,11 @@ void CDiskInfoDlg::AlarmOverheat()
 			
 			if(m_bFahrenheit)
 			{
-				cstr.Format(_T("(%d) %s [%s] %d F\r\n"), i + 1, m_Ata.vars[i].Model, diskStatus, m_Ata.vars[i].Temperature * 9 / 5 + 32);
+				cstr.Format(_T("(%d) %s [%s] %d F\r\n"), i + 1, m_Ata.vars[i].Model.GetString(), diskStatus.GetString(), m_Ata.vars[i].Temperature * 9 / 5 + 32);
 			}
 			else
 			{
-				cstr.Format(_T("(%d) %s [%s] %d C\r\n"), i + 1, m_Ata.vars[i].Model, diskStatus, m_Ata.vars[i].Temperature);
+				cstr.Format(_T("(%d) %s [%s] %d C\r\n"), i + 1, m_Ata.vars[i].Model.GetString(), diskStatus.GetString(), m_Ata.vars[i].Temperature);
 			}
 			
 			overheat += cstr;
@@ -2021,17 +2029,17 @@ void CDiskInfoDlg::OnTimer(UINT_PTR nIDEvent)
 				if (years > 0)
 				{
 					title.Format(_T("%d %s %d %s %d %s%s"),
-						years, i18n(_T("Dialog"), _T("POWER_ON_YEARS_UNIT")),
-						days, i18n(_T("Dialog"), _T("POWER_ON_DAYS_UNIT")),
-						hours, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")),
-						IsMinutesT);
+						years, i18n(_T("Dialog"), _T("POWER_ON_YEARS_UNIT")).GetString(),
+						days, i18n(_T("Dialog"), _T("POWER_ON_DAYS_UNIT")).GetString(),
+						hours, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")).GetString(),
+						IsMinutesT.GetString());
 				}
 				else
 				{
 					title.Format(_T("%d %s %d %s%s"),
-						days, i18n(_T("Dialog"), _T("POWER_ON_DAYS_UNIT")),
-						hours, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")),
-						IsMinutesT);
+						days, i18n(_T("Dialog"), _T("POWER_ON_DAYS_UNIT")).GetString(),
+						hours, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")).GetString(),
+						IsMinutesT.GetString());
 				}
 				m_CtrlPowerOnHours.SetToolTipText(title + L"  ");
 			}
@@ -2247,7 +2255,7 @@ void CDiskInfoDlg::AutoAamApmAdaption()
 		value =  GetPrivateProfileIntFx(_T("AamValue"), m_Ata.vars[i].ModelSerial, -1, m_Ini);
 		if(status == 1 /* Enabled */ && value != -1)
 		{
-			m_Ata.EnableAam(i, value);
+			m_Ata.EnableAam(i, (BYTE)value);
 			m_Ata.UpdateIdInfo(i);
 			DebugPrint(_T("m_Ata.EnableAam"));
 		}
@@ -2271,7 +2279,7 @@ void CDiskInfoDlg::AutoAamApmAdaption()
 		value  = GetPrivateProfileIntFx(_T("ApmValue"), m_Ata.vars[i].ModelSerial, -1, m_Ini);
 		if(status == 1 /* Enabled */ && value != -1)
 		{
-			m_Ata.EnableApm(i, value);
+			m_Ata.EnableApm(i, (BYTE)value);
 			m_Ata.UpdateIdInfo(i);
 			DebugPrint(_T("m_Ata.EnableApm"));
 		}
@@ -2316,12 +2324,12 @@ void CDiskInfoDlg::OnBnClickedButtonDisk7(){SelectDrive(7 + m_DriveMenuPage * 8)
 void CDiskInfoDlg::SetControlFont()
 {
 #ifdef SUISHO_SHIZUKU_SUPPORT
-	BYTE textAlpha = TEXT_ALPHA;
+	//BYTE textAlpha = TEXT_ALPHA;
 //	COLORREF textColor = RGB(77, 77, 77);
-	COLORREF textColor = m_LabelText;
+	//COLORREF textColor = m_LabelText;
 #else
-	BYTE textAlpha = 255;
-	COLORREF textColor = m_LabelText;
+	///BYTE textAlpha = 255;
+	//COLORREF textColor = m_LabelText;
 #endif
 
 	m_List.SetFontEx(m_FontFace, 12, m_ZoomRatio, m_FontRatio, FW_NORMAL, m_FontRender);

--- a/DiskInfoDlgCopy.cpp
+++ b/DiskInfoDlgCopy.cpp
@@ -93,12 +93,12 @@ void CDiskInfoDlg::SaveText(CString fileName)
 		if(m_Ata.vars[i].TotalDiskSize >= 1000)
 		{
 			temp.Format(_T(" (%02d) %s : %.1f GB"), i + 1,
-				m_Ata.vars[i].Model, m_Ata.vars[i].TotalDiskSize / 1000.0);
+				m_Ata.vars[i].Model.GetString(), m_Ata.vars[i].TotalDiskSize / 1000.0);
 		}
 		else
 		{
 			temp.Format(_T(" (%02d) %s : %d MB"), i + 1,
-				m_Ata.vars[i].Model, m_Ata.vars[i].TotalDiskSize);
+				m_Ata.vars[i].Model.GetString(), m_Ata.vars[i].TotalDiskSize);
 		}
 
 		cstr += temp;
@@ -107,36 +107,36 @@ void CDiskInfoDlg::SaveText(CString fileName)
 			if(m_Ata.vars[i].PhysicalDriveId < 0)
 			{
 				temp.Format(_T(" [X/%d/%d, %s]"),
-					m_Ata.vars[i].ScsiPort, m_Ata.vars[i].sasPhyEntity.bPortIdentifier, m_Ata.vars[i].CommandTypeString);
+					m_Ata.vars[i].ScsiPort, m_Ata.vars[i].sasPhyEntity.bPortIdentifier, m_Ata.vars[i].CommandTypeString.GetString());
 			}
 			else
 			{
 				temp.Format(_T(" [%d/%d/%d, %s]"),
-					m_Ata.vars[i].PhysicalDriveId, m_Ata.vars[i].ScsiPort, m_Ata.vars[i].sasPhyEntity.bPortIdentifier, m_Ata.vars[i].CommandTypeString);
+					m_Ata.vars[i].PhysicalDriveId, m_Ata.vars[i].ScsiPort, m_Ata.vars[i].sasPhyEntity.bPortIdentifier, m_Ata.vars[i].CommandTypeString.GetString());
 			}
 		}
 		else if(m_Ata.vars[i].PhysicalDriveId < 0)
 		{
 			temp.Format(_T(" [X/%d/%d, %s]"),
-				m_Ata.vars[i].ScsiPort, m_Ata.vars[i].ScsiTargetId, m_Ata.vars[i].CommandTypeString);
+				m_Ata.vars[i].ScsiPort, m_Ata.vars[i].ScsiTargetId, m_Ata.vars[i].CommandTypeString.GetString());
 		}
 		else if(m_Ata.vars[i].ScsiPort < 0)
 		{
 			if(m_Ata.vars[i].UsbVendorId > 0 && m_Ata.vars[i].UsbProductId > 0)
 			{
 				temp.Format(_T(" [%d/X/X, %s] (V=%04X, P=%04X)"),
-					m_Ata.vars[i].PhysicalDriveId, m_Ata.vars[i].CommandTypeString, m_Ata.vars[i].UsbVendorId, m_Ata.vars[i].UsbProductId);
+					m_Ata.vars[i].PhysicalDriveId, m_Ata.vars[i].CommandTypeString.GetString(), m_Ata.vars[i].UsbVendorId, m_Ata.vars[i].UsbProductId);
 			}
 			else
 			{
 				temp.Format(_T(" [%d/X/X, %s]"),
-					m_Ata.vars[i].PhysicalDriveId, m_Ata.vars[i].CommandTypeString);
+					m_Ata.vars[i].PhysicalDriveId, m_Ata.vars[i].CommandTypeString.GetString());
 			}
 		}
 		else
 		{
 			temp.Format(_T(" [%d/%d/%d, %s]"),
-				m_Ata.vars[i].PhysicalDriveId, m_Ata.vars[i].ScsiPort, m_Ata.vars[i].ScsiTargetId, m_Ata.vars[i].CommandTypeString);
+				m_Ata.vars[i].PhysicalDriveId, m_Ata.vars[i].ScsiPort, m_Ata.vars[i].ScsiTargetId, m_Ata.vars[i].CommandTypeString.GetString());
 		}
 
 		cstr += temp;
@@ -224,7 +224,7 @@ void CDiskInfoDlg::SaveText(CString fileName)
 		else
 		{
 			cstr.Format(_T("       Enclosure : %s (V=%04X, P=%04X, %s)"),
-				m_Ata.vars[i].Enclosure, m_Ata.vars[i].UsbVendorId, m_Ata.vars[i].UsbProductId, m_Ata.vars[i].CommandTypeString);		
+				m_Ata.vars[i].Enclosure.GetString(), m_Ata.vars[i].UsbVendorId, m_Ata.vars[i].UsbProductId, m_Ata.vars[i].CommandTypeString.GetString());
 			if(! m_Ata.vars[i].SsdVendorString.IsEmpty())
 			{
 				cstr += _T(" - ") + m_Ata.vars[i].SsdVendorString;
@@ -266,7 +266,7 @@ void CDiskInfoDlg::SaveText(CString fileName)
 			drive.Replace(_T("%MINOR_VERSION%"), m_Ata.vars[i].MinorVersion);
 		}		
 
-		temp.Format(_T("%s | %s"), m_Ata.vars[i].CurrentTransferMode, m_Ata.vars[i].MaxTransferMode);
+		temp.Format(_T("%s | %s"), m_Ata.vars[i].CurrentTransferMode.GetString(), m_Ata.vars[i].MaxTransferMode.GetString());
 		drive.Replace(_T("%TRANSFER_MODE%"), temp);
 
 		if (m_Ata.vars[i].CommandType == m_Ata.CMD_TYPE_AMD_RC2)
@@ -305,7 +305,7 @@ void CDiskInfoDlg::SaveText(CString fileName)
 			{
 				IsMinutes = _T("");
 			}
-			cstr.Format(_T("%d %s%s"), m_Ata.vars[i].MeasuredPowerOnHours, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")), IsMinutes);
+			cstr.Format(_T("%d %s%s"), m_Ata.vars[i].MeasuredPowerOnHours, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")).GetString(), IsMinutes.GetString());
 		}
 		else if(m_Ata.vars[i].DetectedPowerOnHours >= 0)
 		{
@@ -320,7 +320,7 @@ void CDiskInfoDlg::SaveText(CString fileName)
 			{
 				IsMinutes = _T("");
 			}
-			cstr.Format(_T("%d %s%s"), m_Ata.vars[i].DetectedPowerOnHours, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")), IsMinutes);
+			cstr.Format(_T("%d %s%s"), m_Ata.vars[i].DetectedPowerOnHours, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")).GetString(), IsMinutes.GetString());
 		}
 		else
 		{
@@ -330,7 +330,7 @@ void CDiskInfoDlg::SaveText(CString fileName)
 
 		if(m_Ata.vars[i].PowerOnCount > 0)
 		{
-			cstr.Format(_T("%d %s"), m_Ata.vars[i].PowerOnCount, i18n(_T("Dialog"), _T("POWER_ON_COUNT_UNIT")));
+			cstr.Format(_T("%d %s"), m_Ata.vars[i].PowerOnCount, i18n(_T("Dialog"), _T("POWER_ON_COUNT_UNIT")).GetString());
 		}
 		else
 		{
@@ -502,7 +502,7 @@ void CDiskInfoDlg::SaveText(CString fileName)
 
 		if (m_Ata.vars[i].CommandType == m_Ata.CMD_TYPE_AMD_RC2)
 		{
-			cstr.Format(_T("     Queue Depth : %s\r\n"), i18n(_T("Dialog"), _T("UNKNOWN")));
+			cstr.Format(_T("     Queue Depth : %s\r\n"), i18n(_T("Dialog"), _T("UNKNOWN")).GetString());
 		}
 		else if(0 <= m_Ata.vars[i].IdentifyDevice.A.QueueDepth && m_Ata.vars[i].IdentifyDevice.A.QueueDepth < 32)
 		{
@@ -698,9 +698,9 @@ void CDiskInfoDlg::SaveText(CString fileName)
 				{
 					cstr.Format(_T("%02X %s %s %s %02X%02X%02X%02X%02X%02X%02X %s\r\n"),
 						m_Ata.vars[i].Attribute[j].Id,
-						__Number(m_Ata.vars[i].Attribute[j].CurrentValue),
-						__Number(m_Ata.vars[i].Attribute[j].WorstValue),
-						__Number(m_Ata.vars[i].Threshold[j].ThresholdValue),
+						__Number(m_Ata.vars[i].Attribute[j].CurrentValue).GetString(),
+						__Number(m_Ata.vars[i].Attribute[j].WorstValue).GetString(),
+						__Number(m_Ata.vars[i].Threshold[j].ThresholdValue).GetString(),
 						m_Ata.vars[i].Attribute[j].Reserved,
 						m_Ata.vars[i].Attribute[j].RawValue[5],
 						m_Ata.vars[i].Attribute[j].RawValue[4],
@@ -716,7 +716,7 @@ void CDiskInfoDlg::SaveText(CString fileName)
 				{
 					cstr.Format(_T("%02X %s %02X%02X%02X%02X%02X%02X%02X%02X %s\r\n"),
 						m_Ata.vars[i].Attribute[j].Id,
-						__Number(m_Ata.vars[i].Attribute[j].CurrentValue),
+						__Number(m_Ata.vars[i].Attribute[j].CurrentValue).GetString(),
 						m_Ata.vars[i].Attribute[j].Reserved,
 						m_Ata.vars[i].Attribute[j].RawValue[5],
 						m_Ata.vars[i].Attribute[j].RawValue[4],
@@ -749,9 +749,9 @@ void CDiskInfoDlg::SaveText(CString fileName)
 					{
 						cstr.Format(_T("%02X %s %s %s %02X%02X%02X%02X%02X%02X %s\r\n"),
 							m_Ata.vars[i].Attribute[j].Id,
-							__Number(m_Ata.vars[i].Attribute[j].CurrentValue),
-							__Number(m_Ata.vars[i].Attribute[j].WorstValue),
-							__Number(m_Ata.vars[i].Threshold[j].ThresholdValue),
+							__Number(m_Ata.vars[i].Attribute[j].CurrentValue).GetString(),
+							__Number(m_Ata.vars[i].Attribute[j].WorstValue).GetString(),
+							__Number(m_Ata.vars[i].Threshold[j].ThresholdValue).GetString(),
 							m_Ata.vars[i].Attribute[j].RawValue[5],
 							m_Ata.vars[i].Attribute[j].RawValue[4],
 							m_Ata.vars[i].Attribute[j].RawValue[3],
@@ -765,8 +765,8 @@ void CDiskInfoDlg::SaveText(CString fileName)
 					{
 						cstr.Format(_T("%02X %s %s --- %02X%02X%02X%02X%02X%02X %s\r\n"),
 							m_Ata.vars[i].Attribute[j].Id,
-							__Number(m_Ata.vars[i].Attribute[j].CurrentValue),
-							__Number(m_Ata.vars[i].Attribute[j].WorstValue),
+							__Number(m_Ata.vars[i].Attribute[j].CurrentValue).GetString(),
+							__Number(m_Ata.vars[i].Attribute[j].WorstValue).GetString(),
 							m_Ata.vars[i].Attribute[j].RawValue[5],
 							m_Ata.vars[i].Attribute[j].RawValue[4],
 							m_Ata.vars[i].Attribute[j].RawValue[3],
@@ -954,16 +954,20 @@ void CDiskInfoDlg::SaveText(CString fileName)
 			HGLOBAL clipbuffer;
 			TCHAR* buffer;
 			EmptyClipboard();
-			clipbuffer = GlobalAlloc(GMEM_DDESHARE, sizeof(TCHAR) * (clip.GetLength() + 1));
-			buffer = (TCHAR*)GlobalLock(clipbuffer);
-			_tcscpy_s(buffer, clip.GetLength() + 1, LPCTSTR(clip));
-			GlobalUnlock(clipbuffer);
+			clipbuffer = GlobalAlloc(GMEM_DDESHARE, sizeof(TCHAR) * ((size_t)clip.GetLength() + 1));
+			if (clipbuffer) {
+				buffer = (TCHAR*)GlobalLock(clipbuffer);
+				if (buffer) {
+					_tcscpy_s(buffer, (size_t)clip.GetLength() + 1, LPCTSTR(clip));
+					GlobalUnlock(clipbuffer);
 #ifdef _UNICODE
-			SetClipboardData(CF_UNICODETEXT, clipbuffer);
+					SetClipboardData(CF_UNICODETEXT, clipbuffer);
 #else
-			SetClipboardData(CF_OEMTEXT, clipbuffer);
+					SetClipboardData(CF_OEMTEXT, clipbuffer);
 #endif
-			CloseClipboard();
+					CloseClipboard();
+				}
+			}
 		}
 	}
 	else

--- a/DiskInfoDlgInit.cpp
+++ b/DiskInfoDlgInit.cpp
@@ -29,7 +29,7 @@ int CALLBACK EnumFontFamExProcDefaultFont(ENUMLOGFONTEX *lpelfe, NEWTEXTMETRICEX
 
 BOOL CDiskInfoDlg::OnInitDialog()
 {
-	BOOL result = FALSE;
+	//BOOL result = FALSE;
 
 	CMainDialogFx::OnInitDialog();
 
@@ -74,7 +74,7 @@ BOOL CDiskInfoDlg::OnInitDialog()
 		m_FontRatio = m_FontScale / 100.0;
 	}
 
-	m_FontRender = GetPrivateProfileInt(L"Setting", L"FontRender", CLEARTYPE_NATURAL_QUALITY, m_Ini);
+	m_FontRender = (BYTE)GetPrivateProfileInt(L"Setting", L"FontRender", CLEARTYPE_NATURAL_QUALITY, m_Ini);
 	if (m_FontRender > CLEARTYPE_NATURAL_QUALITY)
 	{
 		m_FontRender = CLEARTYPE_NATURAL_QUALITY;
@@ -336,10 +336,10 @@ void CDiskInfoDlg::InitAta(BOOL useWmi, BOOL advancedDiskSearch, PBOOL flagChang
 		}
 		m_Ata.vars[i].AlarmHealthStatus = GetPrivateProfileIntFx(_T("AlarmHealthStatus"), m_Ata.vars[i].ModelSerial, 1, m_Ini);
 
-		m_Ata.vars[i].Threshold05     = GetPrivateProfileIntFx(_T("ThreasholdOfCaution05"), m_Ata.vars[i].ModelSerial, 1, m_Ini);
-		m_Ata.vars[i].ThresholdC5     = GetPrivateProfileIntFx(_T("ThreasholdOfCautionC5"), m_Ata.vars[i].ModelSerial, 1, m_Ini);
-		m_Ata.vars[i].ThresholdC6     = GetPrivateProfileIntFx(_T("ThreasholdOfCautionC6"), m_Ata.vars[i].ModelSerial, 1, m_Ini);
-		m_Ata.vars[i].ThresholdFF     = GetPrivateProfileIntFx(_T("ThreasholdOfCautionFF"), m_Ata.vars[i].ModelSerial, 10, m_Ini);
+		m_Ata.vars[i].Threshold05     = (WORD)GetPrivateProfileIntFx(_T("ThreasholdOfCaution05"), m_Ata.vars[i].ModelSerial, 1, m_Ini);
+		m_Ata.vars[i].ThresholdC5     = (WORD)GetPrivateProfileIntFx(_T("ThreasholdOfCautionC5"), m_Ata.vars[i].ModelSerial, 1, m_Ini);
+		m_Ata.vars[i].ThresholdC6     = (WORD)GetPrivateProfileIntFx(_T("ThreasholdOfCautionC6"), m_Ata.vars[i].ModelSerial, 1, m_Ini);
+		m_Ata.vars[i].ThresholdFF     = (WORD)GetPrivateProfileIntFx(_T("ThreasholdOfCautionFF"), m_Ata.vars[i].ModelSerial, 10, m_Ini);
 
 		m_Ata.vars[i].DiskStatus = m_Ata.CheckDiskStatus(i);
 		DebugPrint(_T("SaveSmartInfo(i)"));
@@ -702,12 +702,12 @@ void CDiskInfoDlg::InitDriveList()
 				if (m_bFahrenheit)
 				{
 					m_LiDisk[i % 8].Format(_T("%s%s%d °F%s%s"),
-						diskStatus, delimiter, m_Ata.vars[i].Temperature * 9 / 5 + 32, delimiter, driveLetter);
+						diskStatus.GetString(), delimiter.GetString(), m_Ata.vars[i].Temperature * 9 / 5 + 32, delimiter.GetString(), driveLetter.GetString());
 				}
 				else
 				{
 					m_LiDisk[i % 8].Format(_T("%s%s%d °C%s%s"),
-						diskStatus, delimiter, m_Ata.vars[i].Temperature, delimiter, driveLetter);
+						diskStatus.GetString(), delimiter.GetString(), m_Ata.vars[i].Temperature, delimiter.GetString(), driveLetter.GetString());
 				}
 			}
 			else if(m_Ata.vars[i].IsSmartEnabled && m_Ata.vars[i].Temperature > -300)
@@ -715,44 +715,44 @@ void CDiskInfoDlg::InitDriveList()
 				if(m_bFahrenheit)
 				{
 					m_LiDisk[i % 8].Format(_T("%s%s%d °F%s%s"), 
-								diskStatus, delimiter, m_Ata.vars[i].Temperature * 9 / 5 + 32, delimiter, driveLetter);
+								diskStatus.GetString(), delimiter.GetString(), m_Ata.vars[i].Temperature * 9 / 5 + 32, delimiter.GetString(), driveLetter.GetString());
 				}
 				else
 				{
 					m_LiDisk[i % 8].Format(_T("%s%s%d °C%s%s"), 
-								diskStatus, delimiter, m_Ata.vars[i].Temperature, delimiter, driveLetter);
+								diskStatus.GetString(), delimiter.GetString(), m_Ata.vars[i].Temperature, delimiter.GetString(), driveLetter.GetString());
 				}
 			}
 			else if(m_Ata.vars[i].IsSmartEnabled)
 			{
 				if(m_bFahrenheit)
 				{
-					m_LiDisk[i % 8].Format(_T("%s%s-- °F%s%s"), diskStatus, delimiter, delimiter, driveLetter);
+					m_LiDisk[i % 8].Format(_T("%s%s-- °F%s%s"), diskStatus.GetString(), delimiter.GetString(), delimiter.GetString(), driveLetter.GetString());
 				}
 				else
 				{
-					m_LiDisk[i % 8].Format(_T("%s%s-- °C%s%s"), diskStatus, delimiter, delimiter, driveLetter);
+					m_LiDisk[i % 8].Format(_T("%s%s-- °C%s%s"), diskStatus.GetString(), delimiter.GetString(), delimiter.GetString(), driveLetter.GetString());
 				}
 			}
 			else
 			{
 				if(m_bFahrenheit)
 				{
-					m_LiDisk[i % 8].Format(_T("----%s-- °F%s%s"), delimiter, delimiter, driveLetter);
+					m_LiDisk[i % 8].Format(_T("----%s-- °F%s%s"), delimiter.GetString(), delimiter.GetString(), driveLetter.GetString());
 				}
 				else
 				{
-					m_LiDisk[i % 8].Format(_T("----%s-- °C%s%s"), delimiter, delimiter, driveLetter);
+					m_LiDisk[i % 8].Format(_T("----%s-- °C%s%s"), delimiter.GetString(), delimiter.GetString(), driveLetter.GetString());
 				}
 			}
 
 			if(m_Ata.vars[i].PhysicalDriveId >= 0)
 			{
-				cstr.Format(_T("Disk %d : %s %.1f GB\n%s"), m_Ata.vars[i].PhysicalDriveId, m_Ata.vars[i].Model, m_Ata.vars[i].TotalDiskSize / 1000.0, GetLogicalDriveInfo(i));
+				cstr.Format(_T("Disk %d : %s %.1f GB\n%s"), m_Ata.vars[i].PhysicalDriveId, m_Ata.vars[i].Model.GetString(), m_Ata.vars[i].TotalDiskSize / 1000.0, GetLogicalDriveInfo(i).GetString());
 			}
 			else
 			{
-				cstr.Format(_T("Disk -- : %s %.1f GB\n%s"), m_Ata.vars[i].Model, m_Ata.vars[i].TotalDiskSize / 1000.0, GetLogicalDriveInfo(i));
+				cstr.Format(_T("Disk -- : %s %.1f GB\n%s"), m_Ata.vars[i].Model.GetString(), m_Ata.vars[i].TotalDiskSize / 1000.0, GetLogicalDriveInfo(i).GetString());
 			}
 			
 			m_ButtonDisk[i % 8].SetToolTipText(cstr);

--- a/DiskInfoDlgMenu.cpp
+++ b/DiskInfoDlgMenu.cpp
@@ -113,9 +113,8 @@ void CDiskInfoDlg::ShowGraphDlg(int index)
 	CString cstr;
 	GetModuleFileName(NULL, path, MAX_PATH);
 
-	STARTUPINFO si = {0};
-	PROCESS_INFORMATION pi = {0};
-	si.cb			= sizeof(STARTUPINFO);
+	STARTUPINFO si = { sizeof(STARTUPINFO) };
+	PROCESS_INFORMATION pi = {};
 	si.dwFlags		= STARTF_USESHOWWINDOW;
 	si.wShowWindow	= SW_SHOWNORMAL;
 	cstr.Format(_T("\"%s\" /Earthlight %d"), path, index); 
@@ -130,7 +129,7 @@ void CDiskInfoDlg::ShowGraphDlg(int index)
 void CDiskInfoDlg::CreateExchangeInfo()
 {
 	CString cstr;
-	cstr.Format(_T("%d"), m_Ata.vars.GetCount());
+	cstr.Format(_T("%d"), (DWORD)m_Ata.vars.GetCount());
 	WritePrivateProfileString(_T("EXCHANGE"), _T("DetectedDisk"), cstr, m_SmartDir + EXCHANGE_INI);
 
 	for(int i = 0; i < m_Ata.vars.GetCount(); i++)
@@ -630,7 +629,7 @@ void CDiskInfoDlg::OnWorkaroundHD204UI()
 void CDiskInfoDlg::OnWorkaroundIE8MODE()
 {
 	CWaitCursor wait;
-	BOOL flagChangeDisk = FALSE;
+	//BOOL flagChangeDisk = FALSE;
 
 	if(m_bWorkaroundIE8MODE)
 	{
@@ -705,7 +704,7 @@ void CDiskInfoDlg::OnWorkaroundAdataSsd()
 void CDiskInfoDlg::OnWorkaroundIgnoreC4()
 {
 	CWaitCursor wait;
-	BOOL flagChangeDisk = FALSE;
+	//BOOL flagChangeDisk = FALSE;
 
 	if (m_bWorkaroundIgnoreC4)
 	{
@@ -914,7 +913,7 @@ void CDiskInfoDlg::OnStartup()
 
 BOOL CDiskInfoDlg::RegisterStartup()
 {
-	OSVERSIONINFOEX osvi;
+	/*OSVERSIONINFOEX osvi;
 	BOOL bosVersionInfoEx;
 
 	ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
@@ -923,13 +922,13 @@ BOOL CDiskInfoDlg::RegisterStartup()
 	{
 		osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
 		GetVersionEx((OSVERSIONINFO *)&osvi);
-	}
+	}*/
 
 	TCHAR path[MAX_PATH];
 	GetModuleFileName(NULL, path, MAX_PATH);
 	CString cstr;
 
-	if(osvi.dwMajorVersion >= 6)
+	if(UtilityFx__IsWindowsVersionOrGreater(6, 0)/*osvi.dwMajorVersion >= 6*/)
 	{
 		STARTUPINFO si = {0};
 		PROCESS_INFORMATION pi = {0};
@@ -994,8 +993,9 @@ BOOL CDiskInfoDlg::RegisterStartup()
 		HKEY hKey;
 		DWORD disposition;
 		LONG result;
+		TCHAR lpClass[1]{};
 		result = ::RegCreateKeyEx(HKEY_CURRENT_USER, 
-			_T("Software\\Microsoft\\Windows\\CurrentVersion\\Run"), 0, _T(""),
+			_T("Software\\Microsoft\\Windows\\CurrentVersion\\Run"), 0, lpClass/*_T("")*/,
 			REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hKey, &disposition);
 		if(result == ERROR_SUCCESS)
 		{
@@ -1012,7 +1012,7 @@ BOOL CDiskInfoDlg::RegisterStartup()
 
 BOOL CDiskInfoDlg::UnregisterStartup()
 {
-	OSVERSIONINFOEX osvi;
+	/*OSVERSIONINFOEX osvi;
 	BOOL bosVersionInfoEx;
 
 	ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
@@ -1021,15 +1021,15 @@ BOOL CDiskInfoDlg::UnregisterStartup()
 	{
 		osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
 		GetVersionEx((OSVERSIONINFO *)&osvi);
-	}
+	}*/
 
-	if(osvi.dwMajorVersion >= 6)
+	if(UtilityFx__IsWindowsVersionOrGreater(6, 0)/*osvi.dwMajorVersion >= 6*/)
 	{
 		CString cstr;
 
-		STARTUPINFO si = {0};
-		PROCESS_INFORMATION pi = {0};
-		si.cb			= sizeof(STARTUPINFO);
+		STARTUPINFO si = { sizeof(STARTUPINFO) };
+		PROCESS_INFORMATION pi = {};
+		//si.cb			= sizeof(STARTUPINFO);
 		si.dwFlags		= STARTF_USESHOWWINDOW;
 		si.wShowWindow	= SW_HIDE;
 		cstr.Format(_T("schtasks.exe /Delete /tn CrystalDiskInfo /F")); 
@@ -1043,8 +1043,9 @@ BOOL CDiskInfoDlg::UnregisterStartup()
 		HKEY hKey;
 		DWORD disposition;
 		LONG result;
+		TCHAR lpClass[1]{};
 		result = ::RegCreateKeyEx(HKEY_CURRENT_USER, 
-			_T("Software\\Microsoft\\Windows\\CurrentVersion\\Run"), 0, _T(""),
+			_T("Software\\Microsoft\\Windows\\CurrentVersion\\Run"), 0, lpClass/*_T("")*/,
 			REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hKey, &disposition);
 		if(result == ERROR_SUCCESS)
 		{

--- a/DiskInfoDlgTray.cpp
+++ b/DiskInfoDlgTray.cpp
@@ -377,7 +377,7 @@ void CDiskInfoDlg::CreateMainMenu(DWORD index)
 		InsertMenuItem(hDiskMenu[i], -1, TRUE, &subMenuInfo);
 
 		CString cstr;
-		cstr.Format(_T("(%d) %s"), i + 1, m_Ata.vars[i].Model);
+		cstr.Format(_T("(%d) %s"), i + 1, m_Ata.vars[i].Model.GetString());
 		menuInfo.dwTypeData = (LPWSTR)cstr.GetString();
 		menuInfo.wID = 0;
 		menuInfo.hSubMenu = hDiskMenu[i];
@@ -663,7 +663,7 @@ BOOL CDiskInfoDlg::AddTemperatureIcon(DWORD i)
 	CString cstr;
 	CString diskStatus;
 	diskStatus = GetDiskStatus(m_Ata.vars[i].DiskStatus);
-	cstr.Format(_T("(%d) %s [%s]\r\n"), i + 1, m_Ata.vars[i].Model, diskStatus);
+	cstr.Format(_T("(%d) %s [%s]\r\n"), i + 1, m_Ata.vars[i].Model.GetString(), diskStatus.GetString());
 
 	cstr += GetLogicalDriveInfo(i, 128);
 	cstr.TrimRight();
@@ -715,7 +715,7 @@ BOOL CDiskInfoDlg::ModifyTemperatureIcon(DWORD i)
 	CString cstr;
 	CString diskStatus;
 	diskStatus = GetDiskStatus(m_Ata.vars[i].DiskStatus);
-	cstr.Format(_T("(%d) %s [%s]\r\n"), i + 1, m_Ata.vars[i].Model, diskStatus);
+	cstr.Format(_T("(%d) %s [%s]\r\n"), i + 1, m_Ata.vars[i].Model.GetString(), diskStatus.GetString());
 	cstr += GetLogicalDriveInfo(i, 128);
 	cstr.TrimRight();
 
@@ -793,16 +793,16 @@ void CDiskInfoDlg::UpdateToolTip()
 				{
 					if(m_Ata.vars[i].TotalDiskSize >= 1000)
 					{
-						cstr.Format(_T("(%d) %s %.1f GB [%s] %d F\r\n"), i + 1, m_Ata.vars[i].Model,
-							m_Ata.vars[i].TotalDiskSize / 1000.0, diskStatus, m_Ata.vars[i].Temperature * 9 / 5 + 32);
+						cstr.Format(_T("(%d) %s %.1f GB [%s] %d F\r\n"), i + 1, m_Ata.vars[i].Model.GetString(),
+							m_Ata.vars[i].TotalDiskSize / 1000.0, diskStatus.GetString(), m_Ata.vars[i].Temperature * 9 / 5 + 32);
 					}
 					else
 					{
-						cstr.Format(_T("(%d) %s %d MB [%s] %d F\r\n"), i + 1, m_Ata.vars[i].Model,
-							m_Ata.vars[i].TotalDiskSize, diskStatus, m_Ata.vars[i].Temperature * 9 / 5 + 32);
+						cstr.Format(_T("(%d) %s %d MB [%s] %d F\r\n"), i + 1, m_Ata.vars[i].Model.GetString(),
+							m_Ata.vars[i].TotalDiskSize, diskStatus.GetString(), m_Ata.vars[i].Temperature * 9 / 5 + 32);
 					}
 					tipFull += cstr;
-					cstr.Format(_T("(%d) %s %d F\r\n"), i + 1, m_Ata.vars[i].Model, m_Ata.vars[i].Temperature * 9 / 5 + 32);
+					cstr.Format(_T("(%d) %s %d F\r\n"), i + 1, m_Ata.vars[i].Model.GetString(), m_Ata.vars[i].Temperature * 9 / 5 + 32);
 					tipMid += cstr;
 					cstr.Format(_T("(%d)%dF\r\n"), i + 1, m_Ata.vars[i].Temperature * 9 / 5 + 32);
 					tipShort += cstr;
@@ -811,16 +811,16 @@ void CDiskInfoDlg::UpdateToolTip()
 				{
 					if(m_Ata.vars[i].TotalDiskSize >= 1000)
 					{
-						cstr.Format(_T("(%d) %s %.1f GB [%s] %d C\r\n"), i + 1, m_Ata.vars[i].Model,
-							m_Ata.vars[i].TotalDiskSize / 1000.0, diskStatus, m_Ata.vars[i].Temperature);
+						cstr.Format(_T("(%d) %s %.1f GB [%s] %d C\r\n"), i + 1, m_Ata.vars[i].Model.GetString(),
+							m_Ata.vars[i].TotalDiskSize / 1000.0, diskStatus.GetString(), m_Ata.vars[i].Temperature);
 					}
 					else
 					{
-						cstr.Format(_T("(%d) %s %d MB [%s] %d C\r\n"), i + 1, m_Ata.vars[i].Model,
-							m_Ata.vars[i].TotalDiskSize, diskStatus, m_Ata.vars[i].Temperature);
+						cstr.Format(_T("(%d) %s %d MB [%s] %d C\r\n"), i + 1, m_Ata.vars[i].Model.GetString(),
+							m_Ata.vars[i].TotalDiskSize, diskStatus.GetString(), m_Ata.vars[i].Temperature);
 					}
 					tipFull += cstr;
-					cstr.Format(_T("(%d) %s %d C\r\n"), i + 1, m_Ata.vars[i].Model, m_Ata.vars[i].Temperature);
+					cstr.Format(_T("(%d) %s %d C\r\n"), i + 1, m_Ata.vars[i].Model.GetString(), m_Ata.vars[i].Temperature);
 					tipMid += cstr;
 					cstr.Format(_T("(%d)%dC\r\n"), i + 1, m_Ata.vars[i].Temperature);
 					tipShort += cstr;
@@ -830,18 +830,18 @@ void CDiskInfoDlg::UpdateToolTip()
 			{
 				if(m_Ata.vars[i].TotalDiskSize >= 1000)
 				{
-					cstr.Format(_T("(%d) %s %.1f GB [%s]\r\n"), i + 1, m_Ata.vars[i].Model,
-						m_Ata.vars[i].TotalDiskSize / 1000.0, diskStatus);
+					cstr.Format(_T("(%d) %s %.1f GB [%s]\r\n"), i + 1, m_Ata.vars[i].Model.GetString(),
+						m_Ata.vars[i].TotalDiskSize / 1000.0, diskStatus.GetString());
 				}
 				else
 				{
-					cstr.Format(_T("(%d) %s %d MB [%s]\r\n"), i + 1, m_Ata.vars[i].Model,
-						m_Ata.vars[i].TotalDiskSize, diskStatus);
+					cstr.Format(_T("(%d) %s %d MB [%s]\r\n"), i + 1, m_Ata.vars[i].Model.GetString(),
+						m_Ata.vars[i].TotalDiskSize, diskStatus.GetString());
 				}
 				tipFull += cstr;
-				cstr.Format(_T("(%d) %s [%s]\r\n"), i + 1, m_Ata.vars[i].Model, diskStatus);
+				cstr.Format(_T("(%d) %s [%s]\r\n"), i + 1, m_Ata.vars[i].Model.GetString(), diskStatus.GetString());
 				tipMid += cstr;
-				cstr.Format(_T("(%d)[%s]\r\n"), i + 1, diskStatus);
+				cstr.Format(_T("(%d)[%s]\r\n"), i + 1, diskStatus.GetString());
 				tipShort += cstr;
 			}
 		}

--- a/DiskInfoDlgUpdate.cpp
+++ b/DiskInfoDlgUpdate.cpp
@@ -75,10 +75,11 @@ void CDiskInfoDlg::UpdateShareInfo()
 	CString key, cstr;
 	DWORD result;
 	DWORD value;
-	TCHAR str[256];
+	TCHAR str[256]{};
+	TCHAR lpClass[1]{};
 
 	SHDeleteKey(HKEY_CURRENT_USER, REGISTRY_PATH);
-	result = RegCreateKeyEx(HKEY_CURRENT_USER, REGISTRY_PATH, 0, _T(""),
+	result = RegCreateKeyEx(HKEY_CURRENT_USER, REGISTRY_PATH, 0, lpClass/*_T("")*/,
 		REG_OPTION_VOLATILE, KEY_ALL_ACCESS, NULL, &hKey, NULL);
 
 	if (result != ERROR_SUCCESS)
@@ -88,11 +89,12 @@ void CDiskInfoDlg::UpdateShareInfo()
 
 	value = 1;
 	RegSetValueEx(hKey, _T("Version"), 0, REG_DWORD, (CONST BYTE*)&value, sizeof(DWORD));
-	value = GetTickCount();
+	value = (DWORD)GetTickCountFx();
 	RegSetValueEx(hKey, _T("LastUpdate"), 0, REG_DWORD, (CONST BYTE*)&value, sizeof(DWORD));
 	value = (DWORD)m_Ata.vars.GetCount();
 	RegSetValueEx(hKey, _T("DiskCount"), 0, REG_DWORD, (CONST BYTE*)&value, sizeof(DWORD));
 
+	constexpr DWORD sizeof_TCHAR = sizeof(TCHAR);
 	for (int i = 0; i < m_Ata.vars.GetCount(); i++)
 	{
 		result = RegCreateKeyEx(hKey, m_Ata.vars[i].ModelSerial, 0, NULL,
@@ -105,15 +107,15 @@ void CDiskInfoDlg::UpdateShareInfo()
 		key.Format(_T("Disk%d"), i);
 		wsprintf(str, m_Ata.vars[i].ModelSerial);
 		RegSetValueEx(hKey, key, 0, REG_SZ,
-			(CONST BYTE*)&str, (DWORD)(_tcslen(str) + 1) * sizeof(TCHAR));
+			(CONST BYTE*)&str, (DWORD)(_tcslen(str) + 1) * sizeof_TCHAR);
 
 
 		wsprintf(str, m_Ata.vars[i].DriveMap);
 		RegSetValueEx(hSubKey, _T("DriveLetter"), 0, REG_SZ,
-			(CONST BYTE*)&str, (DWORD)(_tcslen(str) + 1) * sizeof(TCHAR));
+			(CONST BYTE*)&str, (DWORD)(_tcslen(str) + 1) * sizeof_TCHAR);
 		wsprintf(str, m_Ata.vars[i].Model);
 		RegSetValueEx(hSubKey, _T("Model"), 0, REG_SZ,
-			(CONST BYTE*)&str, (DWORD)(_tcslen(str) + 1) * sizeof(TCHAR));
+			(CONST BYTE*)&str, (DWORD)(_tcslen(str) + 1) * sizeof_TCHAR);
 
 		if (m_Ata.vars[i].TotalDiskSize >= 1000)
 		{
@@ -124,7 +126,7 @@ void CDiskInfoDlg::UpdateShareInfo()
 			_stprintf_s(str, 256, _T("%d MB"), m_Ata.vars[i].TotalDiskSize);
 		}
 		RegSetValueEx(hSubKey, _T("DiskSize"), 0, REG_SZ,
-			(CONST BYTE*)&str, (DWORD)(_tcslen(str) + 1) * sizeof(TCHAR));
+			(CONST BYTE*)&str, (DWORD)(_tcslen(str) + 1) * sizeof_TCHAR);
 
 		if (m_bFahrenheit)
 		{
@@ -157,13 +159,13 @@ void CDiskInfoDlg::UpdateShareInfo()
 			}
 		}
 		RegSetValueEx(hSubKey, _T("Temperature"), 0, REG_SZ,
-			(CONST BYTE*)&str, (DWORD)(_tcslen(str) + 1) * sizeof(TCHAR));
+			(CONST BYTE*)&str, (DWORD)(_tcslen(str) + 1) * sizeof_TCHAR);
 
 		cstr = GetTemperatureClass(m_Ata.vars[i].Temperature, m_Ata.vars[i].AlarmTemperature);
 		cstr.Replace(L"Green", L"");
 		_stprintf_s(str, 256, _T("%s"), (LPCTSTR)cstr);
 		RegSetValueEx(hSubKey, _T("TemperatureClass"), 0, REG_SZ,
-			(CONST BYTE*)&str, (DWORD)(_tcslen(str) + 1) * sizeof(TCHAR));
+			(CONST BYTE*)&str, (DWORD)(_tcslen(str) + 1) * sizeof_TCHAR);
 
 		value = m_Ata.vars[i].DiskStatus;
 		RegSetValueEx(hSubKey, _T("DiskStatus"), 0, REG_DWORD, (CONST BYTE*)&value, sizeof(DWORD));
@@ -183,7 +185,7 @@ typedef UINT(WINAPI* FuncGetDpiForWindow) (HWND hWnd);
 
 void CDiskInfoDlg::RebuildListHeader(DWORD i, BOOL forceUpdate)
 {
-	static DWORD preVendorId = -1;
+	static DWORD preVendorId = (DWORD)-1;
 	int width = 0;
 
 	static FuncGetSystemMetricsForDpi pGetSystemMetricsForDpi = (FuncGetSystemMetricsForDpi)GetProcAddress(GetModuleHandle(_T("User32.dll")), "GetSystemMetricsForDpi");
@@ -711,7 +713,7 @@ BOOL CDiskInfoDlg::UpdateListCtrl(DWORD i)
 		cstr.Format(_T("%02X"), m_Ata.vars[i].Attribute[j].Id);
 		m_List.SetItemText(k, 1, cstr);
 
-		BYTE id = m_Ata.vars[i].Attribute[j].Id;
+		//BYTE id = m_Ata.vars[i].Attribute[j].Id;
 
 		if (m_bSmartEnglish)
 		{
@@ -1109,11 +1111,11 @@ BOOL CDiskInfoDlg::ChangeDisk(DWORD i)
 #else
 		cstr.Format(_T("\n%d %%"), m_Ata.vars[i].Life);
 #endif
-		m_DiskStatus.Format(_T("%s %s"), diskStatus, cstr);
+		m_DiskStatus.Format(_T("%s %s"), diskStatus.GetString(), cstr.GetString());
 	}
 	else
 	{
-		m_DiskStatus.Format(_T("%s"), diskStatus);
+		m_DiskStatus.Format(_T("%s"), diskStatus.GetString());
 	}
 	m_CtrlDiskStatus.SetToolTipText(diskStatusReason);
 	m_CtrlDiskStatus.ReloadImage(IP(className), 1);
@@ -1217,7 +1219,7 @@ BOOL CDiskInfoDlg::ChangeDisk(DWORD i)
 	{
 		if (m_Ata.vars[i].PowerOnCount > 0)
 		{
-			m_PowerOnCount.Format(_T("%d %s"), m_Ata.vars[i].PowerOnCount, i18n(_T("Dialog"), _T("POWER_ON_COUNT_UNIT")));
+			m_PowerOnCount.Format(_T("%d %s"), m_Ata.vars[i].PowerOnCount, i18n(_T("Dialog"), _T("POWER_ON_COUNT_UNIT")).GetString());
 		}
 		else
 		{
@@ -1258,17 +1260,17 @@ BOOL CDiskInfoDlg::ChangeDisk(DWORD i)
 				if (years > 0)
 				{
 					title.Format(_T("%d %s %d %s %d %s%s\r\n%s"),
-						years, i18n(_T("Dialog"), _T("POWER_ON_YEARS_UNIT")),
-						days, i18n(_T("Dialog"), _T("POWER_ON_DAYS_UNIT")),
-						hours, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")),
-						IsMinutesT, i18n(_T("Message"), _T("DETECT_UNIT_POWER_ON_HOURS")));
+						years, i18n(_T("Dialog"), _T("POWER_ON_YEARS_UNIT")).GetString(),
+						days, i18n(_T("Dialog"), _T("POWER_ON_DAYS_UNIT")).GetString(),
+						hours, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")).GetString(),
+						IsMinutesT.GetString(), i18n(_T("Message"), _T("DETECT_UNIT_POWER_ON_HOURS")).GetString());
 				}
 				else
 				{
 					title.Format(_T("%d %s %d %s%s\r\n%s"),
-						days, i18n(_T("Dialog"), _T("POWER_ON_DAYS_UNIT")),
-						hours, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")),
-						IsMinutesT, i18n(_T("Message"), _T("DETECT_UNIT_POWER_ON_HOURS")));
+						days, i18n(_T("Dialog"), _T("POWER_ON_DAYS_UNIT")).GetString(),
+						hours, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")).GetString(),
+						IsMinutesT.GetString(), i18n(_T("Message"), _T("DETECT_UNIT_POWER_ON_HOURS")).GetString());
 				}
 			}
 			else
@@ -1276,22 +1278,22 @@ BOOL CDiskInfoDlg::ChangeDisk(DWORD i)
 				if (years > 0)
 				{
 					title.Format(_T("%d %s %d %s %d %s%s"),
-						years, i18n(_T("Dialog"), _T("POWER_ON_YEARS_UNIT")),
-						days, i18n(_T("Dialog"), _T("POWER_ON_DAYS_UNIT")),
-						hours, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")),
-						IsMinutesT);
+						years, i18n(_T("Dialog"), _T("POWER_ON_YEARS_UNIT")).GetString(),
+						days, i18n(_T("Dialog"), _T("POWER_ON_DAYS_UNIT")).GetString(),
+						hours, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")).GetString(),
+						IsMinutesT.GetString());
 				}
 				else
 				{
 					title.Format(_T("%d %s %d %s%s"),
-						days, i18n(_T("Dialog"), _T("POWER_ON_DAYS_UNIT")),
-						hours, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")),
-						IsMinutesT);
+						days, i18n(_T("Dialog"), _T("POWER_ON_DAYS_UNIT")).GetString(),
+						hours, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")).GetString(),
+						IsMinutesT.GetString());
 				}
 			}
 
 			m_PowerOnHours.Format(_T("%d%s%s"),
-				powerOnHours, IsMinutes, i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")));
+				powerOnHours, IsMinutes.GetString(), i18n(_T("Dialog"), _T("POWER_ON_HOURS_UNIT")).GetString());
 
 			m_CtrlPowerOnHours.SetToolTipText(title + L"  ");
 
@@ -1616,7 +1618,7 @@ void CDiskInfoDlg::ChangeLang(CString LangName)
 		m_SelectDisk = 0;
 	}
 
-	m_CurrentLangPath.Format(_T("%s\\%s.lang"), m_LangDir, LangName);
+	m_CurrentLangPath.Format(_T("%s\\%s.lang"), m_LangDir.GetString(), LangName.GetString());
 	CString cstr;
 	CMenu *menu = GetMenu();
 	CMenu subMenu;
@@ -2179,17 +2181,17 @@ void CDiskInfoDlg::ChangeLang(CString LangName)
 		CString cstr;
 		if (m_Ata.vars[i].TotalDiskSize >= 1000)
 		{
-			cstr.Format(_T("(%d) %s %.1f GB"), i + 1, m_Ata.vars[i].Model, m_Ata.vars[i].TotalDiskSize / 1000.0);
+			cstr.Format(_T("(%d) %s %.1f GB"), i + 1, m_Ata.vars[i].Model.GetString(), m_Ata.vars[i].TotalDiskSize / 1000.0);
 		}
 		else
 		{
-			cstr.Format(_T("(%d) %s %d MB"), i + 1, m_Ata.vars[i].Model, m_Ata.vars[i].TotalDiskSize);
+			cstr.Format(_T("(%d) %s %d MB"), i + 1, m_Ata.vars[i].Model.GetString(), m_Ata.vars[i].TotalDiskSize);
 		}
 		subMenuInfo.wID = SELECT_DISK_BASE + i;
 		subMenuInfo.dwTypeData = (LPWSTR)cstr.GetString();
 		subMenu.InsertMenuItem(-1, &subMenuInfo);
 
-		if (i % 8 == 7 && i + 1 != m_Ata.vars.GetCount())
+		if (i % 8 == 7 && i + (INT_PTR)1 != m_Ata.vars.GetCount())
 		{
 			subMenu.AppendMenu(MF_SEPARATOR);
 		}
@@ -2224,11 +2226,11 @@ void CDiskInfoDlg::ChangeLang(CString LangName)
 	{
 		if (m_Ata.vars[i].TotalDiskSize >= 1000)
 		{
-			cstr.Format(_T("(%d) %s %.1f GB"), i + 1, m_Ata.vars[i].Model, m_Ata.vars[i].TotalDiskSize / 1000.0);
+			cstr.Format(_T("(%d) %s %.1f GB"), i + 1, m_Ata.vars[i].Model.GetString(), m_Ata.vars[i].TotalDiskSize / 1000.0);
 		}
 		else
 		{
-			cstr.Format(_T("(%d) %s %d MB"), i + 1, m_Ata.vars[i].Model, m_Ata.vars[i].TotalDiskSize);
+			cstr.Format(_T("(%d) %s %d MB"), i + 1, m_Ata.vars[i].Model.GetString(), m_Ata.vars[i].TotalDiskSize);
 		}
 		subSubMenuInfo.wID = AUTO_REFRESH_TARGET_BASE + i;
 		subSubMenuInfo.dwTypeData = (LPWSTR)cstr.GetString();
@@ -2243,7 +2245,7 @@ void CDiskInfoDlg::ChangeLang(CString LangName)
 
 		subSubMenu.InsertMenuItem(-1, &subSubMenuInfo);
 
-		if (i % 8 == 7 && i + 1 != m_Ata.vars.GetCount())
+		if (i % 8 == 7 && i + (INT_PTR)1 != m_Ata.vars.GetCount())
 		{
 			subSubMenu.AppendMenu(MF_SEPARATOR);
 		}
@@ -2592,7 +2594,7 @@ BOOL CDiskInfoDlg::AppendLog(CString dir, CString disk, CString file, CTime time
 		WritePrivateProfileString(disk, file, str, dir + _T("\\") + SMART_INI);
 
 		CString line;
-		line.Format(_T("%s,%d\n"), time.Format(_T("%Y/%m/%d %H:%M:%S")), value);
+		line.Format(_T("%s,%d\n"), time.Format(_T("%Y/%m/%d %H:%M:%S")).GetString(), value);
 
 		CStdioFile outFile;
 		if (outFile.Open(dir + _T("\\") + file + _T(".csv"),

--- a/DnpService.h
+++ b/DnpService.h
@@ -58,7 +58,7 @@ class	CDnpService
 		//
 		bool EasyStartStop(LPCTSTR pszName, bool b)
 		{
-			bool			ret = false;
+			//bool			ret = false;
 			BOOL			bRet = FALSE;
 			SC_HANDLE		hManager = NULL;
 			SC_HANDLE		hService = NULL;

--- a/EventLog.cpp
+++ b/EventLog.cpp
@@ -13,9 +13,9 @@
 BOOL InstallEventSource()
 {
     HKEY hk = NULL;
-    DWORD level;
+	DWORD level{};
     DWORD length = MAX_PATH;
-    TCHAR fileName[MAX_PATH];
+	TCHAR fileName[MAX_PATH]{};
 
     if(RegOpenKeyEx(HKEY_LOCAL_MACHINE, REGISTRY_KEY, 0, KEY_ALL_ACCESS, &hk) != ERROR_SUCCESS)
 	{
@@ -60,7 +60,7 @@ BOOL InstallEventSource()
 	}
 }
 
-BOOL WriteEventLog(DWORD eventId, WORD eventType, PTCHAR source, CString message)
+BOOL WriteEventLog(DWORD eventId, WORD eventType, const TCHAR*/*PTCHAR*/ source, CString message)
 {
 	HANDLE hEventLog = NULL;
 	DWORD flag = 0;
@@ -72,7 +72,7 @@ BOOL WriteEventLog(DWORD eventId, WORD eventType, PTCHAR source, CString message
 		return FALSE;
 	}
 
-	LPCTSTR str[1];
+	LPCTSTR str[1]{};
 	str[0] = message.GetString();
 
 	if(600 <= eventId && eventId < 700)

--- a/EventLog.h
+++ b/EventLog.h
@@ -8,5 +8,5 @@
 #pragma once
 
 BOOL InstallEventSource();
-BOOL WriteEventLog(DWORD eventId, WORD eventType, PTCHAR source, CString message);
+BOOL WriteEventLog(DWORD eventId, WORD eventType, const TCHAR*/* PTCHAR*/ source, CString message);
 BOOL UninstallEventSource();

--- a/GraphDlg.cpp
+++ b/GraphDlg.cpp
@@ -57,7 +57,7 @@ CGraphDlg::~CGraphDlg()
 	for(int i = 0; i < m_DetectedDisk; i++)
 	{
 		index.Format(_T("Disk%d"), i);
-		value.Format(_T("%d"), ! m_bGraph[i]);
+		value.Format(_T("%d"), ( ! m_bGraph[i] ? 1 : 0 ) );
 		WritePrivateProfileString(_T("GraphHideDisk"), index, value, m_Ini);
 	}
 }
@@ -715,7 +715,7 @@ BOOL CGraphDlg::CheckDisk(DWORD disk)
 {
 	CString cstr;
 
-	m_bGraph[disk] = ! m_bGraph[disk];
+	m_bGraph[disk] = ( ! m_bGraph[disk] ? TRUE : FALSE );
 
 	cstr.Format(_T("Disk%d"), disk);
 	if(m_bGraph[disk])
@@ -752,7 +752,7 @@ void CGraphDlg::InitMenuBar()
 		cstr.Format(_T("Disk%d"), i);
 		SetElementPropertyEx(cstr, DISPID_IHTMLELEMENT_CLASSNAME, _T("visible"));
 		
-		temp.Format(_T("%s\r\n%s"), m_Model[i], m_Serial[i]);
+		temp.Format(_T("%s\r\n%s"), m_Model[i].GetString(), m_Serial[i].GetString());
 		if(! m_Drive[i].IsEmpty())
 		{
 			temp += (_T("\r\n") + m_Drive[i]);
@@ -766,17 +766,17 @@ void CGraphDlg::InitMenuBar()
 
 	CString select;
 
-	cstr.Format(_T("<select id=\"SelectAttributeId\" title=\"%s\" onchange=\"this.click()\">"), i18n(_T("Graph"), _T("PLEASE_SELECT_ITEM"), m_bSmartEnglish));
+	cstr.Format(_T("<select id=\"SelectAttributeId\" title=\"%s\" onchange=\"this.click()\">"), i18n(_T("Graph"), _T("PLEASE_SELECT_ITEM"), m_bSmartEnglish).GetString());
 	select = cstr;
 
 	if(m_IeVersion >= 700)
 	{
-		cstr.Format(_T("<optgroup label=\"%s\">"), i18n(_T("Graph"), _T("ACTUAL_VALUE"), m_bSmartEnglish));
+		cstr.Format(_T("<optgroup label=\"%s\">"), i18n(_T("Graph"), _T("ACTUAL_VALUE"), m_bSmartEnglish).GetString());
 		select += cstr;
 	}
 	else
 	{
-		cstr.Format(_T("<option value=\"513\">%s</option>"), i18n(_T("Graph"), _T("ACTUAL_VALUE"), m_bSmartEnglish));
+		cstr.Format(_T("<option value=\"513\">%s</option>"), i18n(_T("Graph"), _T("ACTUAL_VALUE"), m_bSmartEnglish).GetString());
 		select += cstr;
 		space = _T("&nbsp;&nbsp;");
 		if(SelectedAttributeId == 513)
@@ -808,69 +808,69 @@ void CGraphDlg::InitMenuBar()
 	if (m_Attribute != CAtaSmart::SSD_VENDOR_NVME)
 	{
 		// Reallocated Sectors Count
-		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[05] %s</option>"), SMART_REALLOCATED_SECTORS_COUNT, i18n(_T("Smart"), _T("05"), m_bSmartEnglish));
+		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[05] %s</option>"), SMART_REALLOCATED_SECTORS_COUNT, i18n(_T("Smart"), _T("05"), m_bSmartEnglish).GetString());
 		select += cstr; if (SelectedAttributeId == SMART_REALLOCATED_SECTORS_COUNT) { index = counter; }counter++;
 	}
 
 	// PowerOnHours
-	cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[09] %s</option>"), SMART_POWER_ON_HOURS, i18n(_T("Smart"), _T("09"), m_bSmartEnglish));
+	cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[09] %s</option>"), SMART_POWER_ON_HOURS, i18n(_T("Smart"), _T("09"), m_bSmartEnglish).GetString());
 	select += cstr;if(SelectedAttributeId == SMART_POWER_ON_HOURS){index = counter;}counter++;
 
 	// PowerOnCount
-	cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[0C] %s</option>"), SMART_POWER_ON_COUNT, i18n(_T("Smart"), _T("0C"), m_bSmartEnglish));
+	cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[0C] %s</option>"), SMART_POWER_ON_COUNT, i18n(_T("Smart"), _T("0C"), m_bSmartEnglish).GetString());
 	select += cstr;if(SelectedAttributeId == SMART_POWER_ON_COUNT){index = counter;}counter++;
 
 	// Temperature
 	if(m_bFahrenheit)
 	{
-		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[C2] %s (&deg;F)</option>"), SMART_TEMPERATURE, i18n(_T("Smart"), _T("C2"), m_bSmartEnglish));
+		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[C2] %s (&deg;F)</option>"), SMART_TEMPERATURE, i18n(_T("Smart"), _T("C2"), m_bSmartEnglish).GetString());
 	}
 	else
 	{
-		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[C2] %s (&deg;C)</option>"), SMART_TEMPERATURE, i18n(_T("Smart"), _T("C2"), m_bSmartEnglish));
+		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[C2] %s (&deg;C)</option>"), SMART_TEMPERATURE, i18n(_T("Smart"), _T("C2"), m_bSmartEnglish).GetString());
 	}
 	select += cstr;if(SelectedAttributeId == SMART_TEMPERATURE){index = counter;}counter++;
 	
 	if (m_Attribute != CAtaSmart::SSD_VENDOR_NVME)
 	{
 		// Reallocation Event Count
-		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[C4] %s</option>"), SMART_REALLOCATED_EVENT_COUNT, i18n(_T("Smart"), _T("C4"), m_bSmartEnglish));
+		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[C4] %s</option>"), SMART_REALLOCATED_EVENT_COUNT, i18n(_T("Smart"), _T("C4"), m_bSmartEnglish).GetString());
 		select += cstr; if (SelectedAttributeId == SMART_REALLOCATED_EVENT_COUNT) { index = counter; }counter++;
 
 		// Current Pending Sector Count
-		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[C5] %s</option>"), SMART_CURRENT_PENDING_SECTOR_COUNT, i18n(_T("Smart"), _T("C5"), m_bSmartEnglish));
+		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[C5] %s</option>"), SMART_CURRENT_PENDING_SECTOR_COUNT, i18n(_T("Smart"), _T("C5"), m_bSmartEnglish).GetString());
 		select += cstr; if (SelectedAttributeId == SMART_CURRENT_PENDING_SECTOR_COUNT) { index = counter; }counter++;
 
 		// Off-Line Scan Uncorrectable Sector Count
-		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[C6] %s</option>"), SMART_UNCORRECTABLE_SECTOR_COUNT, i18n(_T("Smart"), _T("C6"), m_bSmartEnglish));
+		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[C6] %s</option>"), SMART_UNCORRECTABLE_SECTOR_COUNT, i18n(_T("Smart"), _T("C6"), m_bSmartEnglish).GetString());
 		select += cstr; if (SelectedAttributeId == SMART_UNCORRECTABLE_SECTOR_COUNT) { index = counter; }counter++;
 	}
 
 	// Life
-	cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[XX] %s</option>"), SMART_LIFE, i18n(_T("SmartSsd"), _T("FF"), m_bSmartEnglish));
+	cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[XX] %s</option>"), SMART_LIFE, i18n(_T("SmartSsd"), _T("FF"), m_bSmartEnglish).GetString());
 	select += cstr;if(SelectedAttributeId == SMART_LIFE){index = counter;}counter++;
 	
 	// HostWrites
-	cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[XX] %s (GB)</option>"), SMART_HOST_WRITES, i18n(_T("Dialog"), _T("TOTAL_HOST_WRITES"), m_bSmartEnglish));
+	cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[XX] %s (GB)</option>"), SMART_HOST_WRITES, i18n(_T("Dialog"), _T("TOTAL_HOST_WRITES"), m_bSmartEnglish).GetString());
 	select += cstr;if(SelectedAttributeId == SMART_HOST_WRITES){index = counter;}counter++;
 	
 	// HostReads
-	cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[XX] %s (GB)</option>"), SMART_HOST_READS, i18n(_T("Dialog"), _T("TOTAL_HOST_READS"), m_bSmartEnglish));
+	cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[XX] %s (GB)</option>"), SMART_HOST_READS, i18n(_T("Dialog"), _T("TOTAL_HOST_READS"), m_bSmartEnglish).GetString());
 	select += cstr;if(SelectedAttributeId == SMART_HOST_READS){index = counter;}counter++;
 
 	if (m_Attribute != CAtaSmart::SSD_VENDOR_NVME)
 	{
 		// NandWrites
-		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[XX] %s (GB)</option>"), SMART_NAND_WRITES, i18n(_T("Dialog"), _T("TOTAL_NAND_WRITES"), m_bSmartEnglish));
+		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[XX] %s (GB)</option>"), SMART_NAND_WRITES, i18n(_T("Dialog"), _T("TOTAL_NAND_WRITES"), m_bSmartEnglish).GetString());
 		select += cstr; if (SelectedAttributeId == SMART_NAND_WRITES) { index = counter; }counter++;
 
 
 		// GBytes Erased
-		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[XX] %s (GB)</option>"), SMART_NAND_ERASED, i18n(_T("SmartSandForce"), _T("64"), m_bSmartEnglish));
+		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[XX] %s (GB)</option>"), SMART_NAND_ERASED, i18n(_T("SmartSandForce"), _T("64"), m_bSmartEnglish).GetString());
 		select += cstr; if (SelectedAttributeId == SMART_NAND_ERASED) { index = counter; }counter++;
 
 		// Wear Leveling Count for Micron
-		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[XX] %s</option>"), SMART_WEAR_LEVELING_COUNT, i18n(_T("Dialog"), _T("WEAR_LEVELING_COUNT"), m_bSmartEnglish));
+		cstr.Format(_T("<option value=\"%d\" selected=\"selected\">[XX] %s</option>"), SMART_WEAR_LEVELING_COUNT, i18n(_T("Dialog"), _T("WEAR_LEVELING_COUNT"), m_bSmartEnglish).GetString());
 		select += cstr; if (SelectedAttributeId == SMART_WEAR_LEVELING_COUNT) { index = counter; }counter++;
 	}
 
@@ -878,12 +878,12 @@ void CGraphDlg::InitMenuBar()
 	{
 		if (m_IeVersion >= 700)
 		{
-			cstr.Format(_T("<optgroup label=\"%s\">"), i18n(_T("Graph"), _T("NORMALIZED_VALUE"), m_bSmartEnglish));
+			cstr.Format(_T("<optgroup label=\"%s\">"), i18n(_T("Graph"), _T("NORMALIZED_VALUE"), m_bSmartEnglish).GetString());
 			select += cstr;
 		}
 		else
 		{
-			cstr.Format(_T("<option value=\"514\">%s</option>"), i18n(_T("Graph"), _T("NORMALIZED_VALUE"), m_bSmartEnglish));
+			cstr.Format(_T("<option value=\"514\">%s</option>"), i18n(_T("Graph"), _T("NORMALIZED_VALUE"), m_bSmartEnglish).GetString());
 			select += cstr;
 			if (SelectedAttributeId == 514)
 			{
@@ -901,11 +901,11 @@ void CGraphDlg::InitMenuBar()
 				cstr.Format(_T("%02X"), i);
 				if (i18n(sectionName, cstr).IsEmpty())
 				{
-					cstr.Format(_T("<option value=\"%d\">%s(%02X) %s</option>"), i, space, i, i18n(_T("Smart"), _T("UNKNOWN"), m_bSmartEnglish));
+					cstr.Format(_T("<option value=\"%d\">%s(%02X) %s</option>"), i, space.GetString(), i, i18n(_T("Smart"), _T("UNKNOWN"), m_bSmartEnglish).GetString());
 				}
 				else
 				{
-					cstr.Format(_T("<option value=\"%d\">%s(%02X) %s</option>"), i, space, i, i18n(sectionName, cstr, m_bSmartEnglish));
+					cstr.Format(_T("<option value=\"%d\">%s(%02X) %s</option>"), i, space.GetString(), i, i18n(sectionName, cstr, m_bSmartEnglish).GetString());
 				}
 				if (SelectedAttributeId == i)
 				{
@@ -1113,11 +1113,11 @@ BOOL CGraphDlg::UpdateGraph()
 		_tzset();
 		if(m_AttributeId == 0x1C3) // Fahrenheit
 		{
-			cstr.Format(_T("[%I64d, %d]"), (ULONGLONG)(time(&dateTime) - m_TimeZoneInformation.Bias * 60) * 1000, value * 9 / 5 + 32);
+			cstr.Format(_T("[%I64d, %d]"), (ULONGLONG)(time(&dateTime) - (time_t)m_TimeZoneInformation.Bias * 60) * 1000, value * 9 / 5 + 32);
 		}
 		else
 		{
-			cstr.Format(_T("[%I64d, %d]"), (ULONGLONG)(time(&dateTime) - m_TimeZoneInformation.Bias * 60) * 1000, value);
+			cstr.Format(_T("[%I64d, %d]"), (ULONGLONG)(time(&dateTime) - (time_t)m_TimeZoneInformation.Bias * 60) * 1000, value);
 		}
 		values += cstr;
 /*		cstr.Format(_T("{label: \"(%d) %s\", data:[%s]}, "),
@@ -1127,14 +1127,14 @@ BOOL CGraphDlg::UpdateGraph()
 		if(m_Drive[i].IsEmpty())
 		{
 			cstr.Format(_T("{label: \"(%d) %s\", color: \"rgb(%d, %d, %d)\", data:[%s]}, "),
-				i + 1, m_ModelEscape[i], 
-				GetRValue(m_LineColor[i]), GetGValue(m_LineColor[i]), GetBValue(m_LineColor[i]), values);
+				i + 1, m_ModelEscape[i].GetString(),
+				GetRValue(m_LineColor[i]), GetGValue(m_LineColor[i]), GetBValue(m_LineColor[i]), values.GetString());
 		}
 		else
 		{
 			cstr.Format(_T("{label: \"(%d) %s [%s]\", color: \"rgb(%d, %d, %d)\", data:[%s]}, "),
-				i + 1, m_ModelEscape[i], m_Drive[i],
-				GetRValue(m_LineColor[i]), GetGValue(m_LineColor[i]), GetBValue(m_LineColor[i]), values);
+				i + 1, m_ModelEscape[i].GetString(), m_Drive[i].GetString(),
+				GetRValue(m_LineColor[i]), GetGValue(m_LineColor[i]), GetBValue(m_LineColor[i]), values.GetString());
 		}
 
 	//	cstr.Format(_T("{label: \"%s\", color: \"rgb(%d, %d, %d)\", data:[%s]}, "),
@@ -1155,7 +1155,7 @@ BOOL CGraphDlg::UpdateGraph()
 		if(threshold >= 0)
 		{
 			cstr.Format(_T("{label: \"%s\", color: \"rgb(%d, %d, %d)\", data:["),
-				i18n(_T("Dialog"), _T("LIST_THRESHOLD"), m_bSmartEnglish),
+				i18n(_T("Dialog"), _T("LIST_THRESHOLD"), m_bSmartEnglish).GetString(),
 				GetRValue(m_LineColor[CAtaSmart::MAX_DISK]),
 				GetGValue(m_LineColor[CAtaSmart::MAX_DISK]),
 				GetBValue(m_LineColor[CAtaSmart::MAX_DISK])
@@ -1163,7 +1163,7 @@ BOOL CGraphDlg::UpdateGraph()
 			arg += cstr;
 			cstr.Format(_T("[%I64d, %d], "), startTime, threshold); 
 			arg += cstr; 
-			cstr.Format(_T("[%I64d, %d]"), (ULONGLONG)(time(&dateTime) - m_TimeZoneInformation.Bias * 60) * 1000, threshold); 
+			cstr.Format(_T("[%I64d, %d]"), (ULONGLONG)(time(&dateTime) - (time_t)m_TimeZoneInformation.Bias * 60) * 1000, threshold);
 			arg += cstr;
 			arg += _T("]}, ");
 		}
@@ -1196,7 +1196,7 @@ selection: { mode: \"xy\" },\
 %s\
 legend: { position: \"%s\", margin: 20 },\
 lines: { show: true }\
-}"), m_TimeFormat, grid, m_LegendPositon);
+}"), m_TimeFormat.GetString(), grid.GetString(), m_LegendPositon.GetString());
 	}
 	else if(max == -1)
 	{
@@ -1208,7 +1208,7 @@ selection: { mode: \"xy\" },\
 legend: { position: \"%s\", margin: 20 },\
 lines: { show: true }\
 %s\
-}"), m_TimeFormat, min, grid, m_LegendPositon, points);
+}"), m_TimeFormat.GetString(), min, grid.GetString(), m_LegendPositon.GetString(), points.GetString());
 	}
 	else
 	{
@@ -1220,7 +1220,7 @@ selection: { mode: \"xy\" },\
 legend: { position: \"%s\", margin: 20 },\
 lines: { show: true }\
 %s\
-}"), m_TimeFormat, min, max, grid, m_LegendPositon, points);
+}"), m_TimeFormat.GetString(), min, max, grid.GetString(), m_LegendPositon.GetString(), points.GetString());
 	}
 
 	// overViewOptions
@@ -1233,7 +1233,7 @@ selection: { mode: \"x\" },\
 %s\
 legend: { show: false },\
 lines: { show: true }\
-}"), grid);
+}"), grid.GetString());
 	}
 	else if(max == -1)
 	{
@@ -1244,7 +1244,7 @@ selection: { mode: \"x\" },\
 %s\
 legend: { show: false },\
 lines: { show: true }\
-}"), grid);
+}"), grid.GetString());
 	}
 	else
 	{
@@ -1255,7 +1255,7 @@ selection: { mode: \"x\" },\
 %s\
 legend: { show: false },\
 lines: { show: true }\
-}"), min, max, grid);
+}"), min, max, grid.GetString());
 	}
 	CallScript(_T("updateData"), arg);
 	CallScript(_T("updateMainViewOptions"), options);
@@ -1266,12 +1266,12 @@ lines: { show: true }\
 	if(m_AttributeId >= 0x100)
 	{
 		cstr.Format(_T("%02X"), m_AttributeId % 256);
-		m_Title.Format(_T("%s"), i18n(_T("Smart"), cstr, m_bSmartEnglish));
+		m_Title.Format(_T("%s"), i18n(_T("Smart"), cstr, m_bSmartEnglish).GetString());
 	}
 	else
 	{
 		cstr.Format(_T("%02X"), m_AttributeId);
-		m_Title.Format(_T("(%02X) %s"), m_AttributeId, i18n(_T("Smart"), cstr, m_bSmartEnglish));
+		m_Title.Format(_T("(%02X) %s"), m_AttributeId, i18n(_T("Smart"), cstr, m_bSmartEnglish).GetString());
 	}
 
 	UpdateData(FALSE);
@@ -1458,8 +1458,8 @@ BOOL CGraphDlg::OnCommand(WPARAM wParam, LPARAM lParam)
 {
 	if(GRAPH_DISK_INDEX <= wParam && wParam <= GRAPH_DISK_INDEX + (CAtaSmart::MAX_DISK + 1) * 100)
 	{
-		int i = (int)(wParam - GRAPH_DISK_INDEX) / 100;
-		int j = (int)(wParam - GRAPH_DISK_INDEX) % 100;
+		//int i = (int)(wParam - GRAPH_DISK_INDEX) / 100;
+		//int j = (int)(wParam - GRAPH_DISK_INDEX) % 100;
 
 		UpdateGraph();
 	}
@@ -1504,7 +1504,7 @@ time_t CGraphDlg::GetTimeT(CString time)
 		index++;
 	}
 
-	return mktime(&t) - m_TimeZoneInformation.Bias * 60;
+	return mktime(&t) - (time_t)m_TimeZoneInformation.Bias * 60;
 }
 
 void CGraphDlg::OnGetMinMaxInfo(MINMAXINFO* lpMMI)
@@ -1548,9 +1548,9 @@ void CGraphDlg::OnSize(UINT nType, int cx, int cy)
 		RECT rect;
 		CString cstr;
 		GetClientRect(&rect);
-		cstr.Format(_T("%d"), (DWORD)((rect.bottom - rect.top) / m_ZoomRatio));
+		cstr.Format(_T("%d"), (DWORD)(((double)rect.bottom - rect.top) / m_ZoomRatio));
 		WritePrivateProfileString(_T("Setting"), _T("GraphHeight"), cstr, m_Ini);	
-		cstr.Format(_T("%d"), (DWORD)((rect.right - rect.left) / m_ZoomRatio));
+		cstr.Format(_T("%d"), (DWORD)(((double)rect.right - rect.left) / m_ZoomRatio));
 		WritePrivateProfileString(_T("Setting"), _T("GraphWidth"), cstr, m_Ini);
 	}
 }

--- a/HealthDlg.cpp
+++ b/HealthDlg.cpp
@@ -261,7 +261,7 @@ void CHealthDlg::InitSelectDisk()
 		{
 			driveLetter.Format(_T("(%s)"), p->m_Ata.vars[i].DriveMap.GetString());
 		}
-		cstr.Format(_T("(%02d) %s %s %s"), i + 1, p->m_Ata.vars.GetAt(i).Model.GetString(), temp, driveLetter);
+		cstr.Format(_T("(%02d) %s %s %s"), i + 1, p->m_Ata.vars.GetAt(i).Model.GetString(), temp.GetString(), driveLetter.GetString());
 
 		m_CtrlSelectDisk.AddString(cstr);
 
@@ -395,14 +395,14 @@ void CHealthDlg::OnApply()
 		WritePrivateProfileStringFx(_T("ThreasholdOfCautionC5"), p->m_Ata.vars[m_DiskIndex].ModelSerial, m_ValueC5, m_Ini);
 		WritePrivateProfileStringFx(_T("ThreasholdOfCautionC6"), p->m_Ata.vars[m_DiskIndex].ModelSerial, m_ValueC6, m_Ini);
 
-		p->m_Ata.vars[m_DiskIndex].Threshold05 = _tstoi(m_Value05);
-		p->m_Ata.vars[m_DiskIndex].ThresholdC5 = _tstoi(m_ValueC5);
-		p->m_Ata.vars[m_DiskIndex].ThresholdC6 = _tstoi(m_ValueC6);
+		p->m_Ata.vars[m_DiskIndex].Threshold05 = (WORD)_tstoi(m_Value05);
+		p->m_Ata.vars[m_DiskIndex].ThresholdC5 = (WORD)_tstoi(m_ValueC5);
+		p->m_Ata.vars[m_DiskIndex].ThresholdC6 = (WORD)_tstoi(m_ValueC6);
 	}
 	else if(p->m_Ata.vars[m_DiskIndex].Life >= 0)
 	{
 		WritePrivateProfileStringFx(_T("ThreasholdOfCautionFF"), p->m_Ata.vars[m_DiskIndex].ModelSerial, m_ValueFF, m_Ini);
-		p->m_Ata.vars[m_DiskIndex].ThresholdFF = _tstoi(m_ValueFF);
+		p->m_Ata.vars[m_DiskIndex].ThresholdFF = (WORD)_tstoi(m_ValueFF);
 	}
 	p->SendMessage(WM_COMMAND, ID_REFRESH);
 }

--- a/Priscilla/ButtonFx.cpp
+++ b/Priscilla/ButtonFx.cpp
@@ -153,10 +153,13 @@ BOOL CButtonFx::InitControl(int x, int y, int width, int height, double zoomRati
 			a = 0;
 		}
 
+		const int max_length = length;
+
 		for (int y = 0; y < (int)(m_CtrlSize.cy * m_ImageCount); y++)
 		{
 			for (int x = 0; x < m_CtrlSize.cx; x++)
 			{
+				if ((y * m_CtrlSize.cx + x) * 4 + 4 > max_length) continue;//over run
 				bitmapBits[(y * m_CtrlSize.cx + x) * 4 + 0] = b;
 				bitmapBits[(y * m_CtrlSize.cx + x) * 4 + 1] = g;
 				bitmapBits[(y * m_CtrlSize.cx + x) * 4 + 2] = r;
@@ -313,6 +316,7 @@ void CButtonFx::DrawControl(CDC* drawDC, LPDRAWITEMSTRUCT lpDrawItemStruct, CBit
 			BYTE* CtlBuffer = new BYTE[CtlMemSize];
 			ctrlBitmap.GetBitmapBits(CtlMemSize, CtlBuffer);
 
+			const int buffer_max = (int)(CtlMemSize > DstMemSize ? DstMemSize : CtlMemSize);
 			int baseY = m_CtrlSize.cy * no;
 			for (LONG py = 0; py < DstBmpInfo.bmHeight; py++)
 			{
@@ -320,6 +324,7 @@ void CButtonFx::DrawControl(CDC* drawDC, LPDRAWITEMSTRUCT lpDrawItemStruct, CBit
 				int cn = (baseY + py) * CtlLineBytes;
 				for (LONG px = 0; px < DstBmpInfo.bmWidth; px++)
 				{
+					if (cn + 4 > buffer_max || dn + 4 > buffer_max)  continue;//buffer over run
 					BYTE a = CtlBuffer[cn + 3];
 					BYTE na = 255 - a;
 					DstBuffer[dn + 0] = (BYTE)((CtlBuffer[cn + 0] * a + DstBuffer[dn + 0] * na) / 255);
@@ -442,7 +447,7 @@ void CButtonFx::DrawString(CDC* drawDC, LPDRAWITEMSTRUCT lpDrawItemStruct)
 	{
 		CRect r;
 		r.top = rect.top + (LONG)(((double)rect.Height()) / arr.GetCount() * i);
-		r.bottom = rect.top + (LONG)(((double)rect.Height()) / arr.GetCount() * (i + 1));
+		r.bottom = rect.top + (LONG)(((double)rect.Height()) / arr.GetCount() * (i + 1.0));
 		r.left = rect.left;
 		r.right = rect.right;
 

--- a/Priscilla/ComboBoxFx.cpp
+++ b/Priscilla/ComboBoxFx.cpp
@@ -163,10 +163,13 @@ BOOL CComboBoxFx::InitControl(int x, int y, int width, int height, double zoomRa
 			a = 0;
 		}
 
+		const int max_length = length;
+
 		for (int y = 0; y < (int)(m_CtrlSize.cy * m_ImageCount); y++)
 		{
 			for (int x = 0; x < m_CtrlSize.cx; x++)
 			{
+				if ((y * m_CtrlSize.cx + x) * 4 + 4 > max_length) continue;//over run
 				bitmapBits[(y * m_CtrlSize.cx + x) * 4 + 0] = b;
 				bitmapBits[(y * m_CtrlSize.cx + x) * 4 + 1] = g;
 				bitmapBits[(y * m_CtrlSize.cx + x) * 4 + 2] = r;
@@ -207,7 +210,7 @@ void CComboBoxFx::SetItemHeightAll(int height, double zoomRatio, double fontRati
 {
 	m_FontHeight = (LONG)(-1 * height * zoomRatio * fontRatio);
 
-	CRect rc = { 0 };
+	CRect rc;//CRect rc = { 0 }; // CRect = { 0 } is bad
 	GetWindowRect(&rc);
 	CComboBox::SetItemHeight(-1, (UINT)(height * zoomRatio - rc.Height() + GetItemHeight(-1)));
 
@@ -401,6 +404,7 @@ void CComboBoxFx::DrawControl(CString title, CDC* drawDC, LPDRAWITEMSTRUCT lpDra
 			BYTE* CtlBuffer = new BYTE[CtlMemSize];
 			ctrlBitmap.GetBitmapBits(CtlMemSize, CtlBuffer);
 
+			const int buffer_max = (int)(CtlMemSize > DstMemSize ? DstMemSize : CtlMemSize);
 			int baseY = m_CtrlSize.cy * no;
 			for (LONG py = 0; py < DstBmpInfo.bmHeight; py++)
 			{
@@ -408,6 +412,7 @@ void CComboBoxFx::DrawControl(CString title, CDC* drawDC, LPDRAWITEMSTRUCT lpDra
 				int cn = (baseY + py) * CtlLineBytes;
 				for (LONG px = 0; px < DstBmpInfo.bmWidth; px++)
 				{
+					if (cn + 4 > buffer_max || dn + 4 > buffer_max)  continue;//buffer over run
 					BYTE a = CtlBuffer[cn + 3];
 					BYTE na = 255 - a;
 					DstBuffer[dn + 0] = (BYTE)((CtlBuffer[cn + 0] * a + DstBuffer[dn + 0] * na) / 255);

--- a/Priscilla/DarkMode.cpp
+++ b/Priscilla/DarkMode.cpp
@@ -179,7 +179,10 @@ void FixDarkScrollBar()
 
 BOOL InitDarkMode()
 {
-	auto RtlGetNtVersionNumbers = reinterpret_cast<fnRtlGetNtVersionNumbers>(GetProcAddress(GetModuleHandleW(L"ntdll.dll"), "RtlGetNtVersionNumbers"));
+	HMODULE dll_ntdll = GetModuleHandleW(L"ntdll.dll");
+	HMODULE dll_user32 = GetModuleHandleW(L"user32.dll");
+	if (!dll_ntdll || !dll_user32) return FALSE;
+	auto RtlGetNtVersionNumbers = reinterpret_cast<fnRtlGetNtVersionNumbers>(GetProcAddress(dll_ntdll, "RtlGetNtVersionNumbers"));
 	if (RtlGetNtVersionNumbers)
 	{
 		DWORD major, minor;
@@ -205,7 +208,7 @@ BOOL InitDarkMode()
 				//_FlushMenuThemes = reinterpret_cast<fnFlushMenuThemes>(GetProcAddress(hUxtheme, MAKEINTRESOURCEA(136)));
 				_IsDarkModeAllowedForWindow = reinterpret_cast<fnIsDarkModeAllowedForWindow>(GetProcAddress(hUxtheme, MAKEINTRESOURCEA(137)));
 
-				_SetWindowCompositionAttribute = reinterpret_cast<fnSetWindowCompositionAttribute>(GetProcAddress(GetModuleHandleW(L"user32.dll"), "SetWindowCompositionAttribute"));
+				_SetWindowCompositionAttribute = reinterpret_cast<fnSetWindowCompositionAttribute>(GetProcAddress(dll_user32, "SetWindowCompositionAttribute"));
 
 				if (_OpenNcThemeData &&
 					_RefreshImmersiveColorPolicyState &&

--- a/Priscilla/DialogFx.cpp
+++ b/Priscilla/DialogFx.cpp
@@ -191,7 +191,7 @@ void CDialogFx::SetClientSize(int sizeX, int sizeY, double zoomRatio)
 void CDialogFx::UpdateBackground(BOOL resize, BOOL bDarkMode)
 {
 	HRESULT hr;
-	BOOL    br = FALSE;
+	//BOOL    br = FALSE;
 	CImage srcBitmap;
 	double ratio = m_ZoomRatio;
 	m_bBkImage = FALSE;

--- a/Priscilla/DialogFx.h
+++ b/Priscilla/DialogFx.h
@@ -67,64 +67,64 @@ protected:
 
 protected:
 	// Dialog
-	BOOL m_bInitializing;
-	BOOL m_bDpiChanging;
-	BOOL m_bShowWindow;
-	BOOL m_bModelessDlg;
-	BOOL m_bHighContrast;
-	BOOL m_bDarkMode;
-	BOOL m_bDisableDarkMode;
-	BOOL m_bBkImage;
-	UINT m_MenuId;
+	BOOL m_bInitializing{};
+	BOOL m_bDpiChanging{};
+	BOOL m_bShowWindow{};
+	BOOL m_bModelessDlg{};
+	BOOL m_bHighContrast{};
+	BOOL m_bDarkMode{};
+	BOOL m_bDisableDarkMode{};
+	BOOL m_bBkImage{};
+	UINT m_MenuId{};
 	CWnd* m_ParentWnd;
 	CWnd* m_DlgWnd;
 	CString m_Ini;
-	HACCEL m_hAccelerator;
-	BOOL m_bDrag;
-	CString m_FontFace;
-	BYTE m_FontRender;
-	int m_FontScale;
-	double m_FontRatio;
+	HACCEL m_hAccelerator{};
+	BOOL m_bDrag{};
+	CString m_FontFace{};
+	BYTE m_FontRender{};
+	int m_FontScale{};
+	double m_FontRatio{};
 
-	int m_MaxSizeX;
-	int m_MinSizeX;
-	int m_MaxSizeY;
-	int m_MinSizeY;
+	int m_MaxSizeX{};
+	int m_MinSizeX{};
+	int m_MaxSizeY{};
+	int m_MinSizeY{};
 
 	// Zoom
-	int m_Dpi;
-	DWORD m_ZoomType;
-	double m_ZoomRatio;
+	int m_Dpi{};
+	DWORD m_ZoomType{};
+	double m_ZoomRatio{};
 
 	// Color for SubClass
-	COLORREF m_LabelText;
-	COLORREF m_MeterText;
-	COLORREF m_ComboText;
-	COLORREF m_ComboTextSelected;
-	COLORREF m_ComboBk;
-	COLORREF m_ComboBkSelected;
-	COLORREF m_ButtonText;
-	COLORREF m_EditText;
-	COLORREF m_EditBk;
-	COLORREF m_ListText1;
-	COLORREF m_ListText2;
-	COLORREF m_ListTextSelected;
-	COLORREF m_ListBk1;
-	COLORREF m_ListBk2;
-	COLORREF m_ListBkSelected;
-	COLORREF m_ListLine1;
-	COLORREF m_ListLine2;
-	COLORREF m_Glass;
-	COLORREF m_Frame;
+	COLORREF m_LabelText{};
+	COLORREF m_MeterText{};
+	COLORREF m_ComboText{};
+	COLORREF m_ComboTextSelected{};
+	COLORREF m_ComboBk{};
+	COLORREF m_ComboBkSelected{};
+	COLORREF m_ButtonText{};
+	COLORREF m_EditText{};
+	COLORREF m_EditBk{};
+	COLORREF m_ListText1{};
+	COLORREF m_ListText2{};
+	COLORREF m_ListTextSelected{};
+	COLORREF m_ListBk1{};
+	COLORREF m_ListBk2{};
+	COLORREF m_ListBkSelected{};
+	COLORREF m_ListLine1{};
+	COLORREF m_ListLine2{};
+	COLORREF m_Glass{};
+	COLORREF m_Frame{};
 
-	BYTE     m_ComboAlpha;
-	BYTE     m_EditAlpha;
-	BYTE     m_GlassAlpha;
+	BYTE     m_ComboAlpha{};
+	BYTE     m_EditAlpha{};
+	BYTE     m_GlassAlpha{};
 
-	BYTE     m_CharacterPosition;
+	BYTE     m_CharacterPosition{};
 
 	// Theme for SubClass
-	int m_OffsetX;
+	int m_OffsetX{};
 	CString m_ThemeDir;
 	CString m_CurrentTheme;
 	CString m_DefaultTheme;

--- a/Priscilla/EditFx.cpp
+++ b/Priscilla/EditFx.cpp
@@ -138,10 +138,13 @@ BOOL CEditFx::InitControl(int x, int y, int width, int height, double zoomRatio,
 			a = 0;
 		}
 
+		const int max_length = length;
+
 		for (int y = 0; y < (int)(m_CtrlSize.cy * m_ImageCount); y++)
 		{
 			for (int x = 0; x < m_CtrlSize.cx; x++)
 			{
+				if ((y * m_CtrlSize.cx + x) * 4 + 4 > max_length) continue;//over run
 				bitmapBits[(y * m_CtrlSize.cx + x) * 4 + 0] = b;
 				bitmapBits[(y * m_CtrlSize.cx + x) * 4 + 1] = g;
 				bitmapBits[(y * m_CtrlSize.cx + x) * 4 + 2] = r;
@@ -352,6 +355,7 @@ void CEditFx::SetupControlImage(CBitmap& bkBitmap, CBitmap& ctrlBitmap)
 			BYTE* CtlBuffer = new BYTE[CtlMemSize];
 			ctrlBitmap.GetBitmapBits(CtlMemSize, CtlBuffer);
 
+			const int buffer_max = (int)(CtlMemSize > DstMemSize ? DstMemSize : CtlMemSize);
 			int baseY = 0;
 			for (LONG py = 0; py < DstBmpInfo.bmHeight; py++)
 			{
@@ -359,6 +363,7 @@ void CEditFx::SetupControlImage(CBitmap& bkBitmap, CBitmap& ctrlBitmap)
 				int cn = (baseY + py) * CtlLineBytes;
 				for (LONG px = 0; px < DstBmpInfo.bmWidth; px++)
 				{
+					if (cn + 4 > buffer_max || dn + 4 > buffer_max)  continue;//buffer over run
 					BYTE a = CtlBuffer[cn + 3];
 					BYTE na = 255 - a;
 					CtlBuffer[dn + 0] = (BYTE)((CtlBuffer[cn + 0] * a + DstBuffer[dn + 0] * na) / 255);

--- a/Priscilla/FontComboBoxFx.cpp
+++ b/Priscilla/FontComboBoxFx.cpp
@@ -16,6 +16,7 @@ IMPLEMENT_DYNAMIC(CFontComboBox, CComboBoxFx)
 
 CFontComboBox::CFontComboBox()
 {
+	m_Brush = NULL;
 }
 
 CFontComboBox::~CFontComboBox()

--- a/Priscilla/HeaderCtrlFx.cpp
+++ b/Priscilla/HeaderCtrlFx.cpp
@@ -96,8 +96,8 @@ void CHeaderCtrlFx::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct)
 	rect.top = rect.bottom - 1;
 	drawDC->FillRect(&rect, &br);
 
-	HDITEM hi;
-	TCHAR str[256];
+	HDITEM hi{};
+	TCHAR str[256]{};
 	hi.mask = HDI_TEXT | HDI_FORMAT;
 	hi.pszText = str;
 	hi.cchTextMax = 256;
@@ -134,7 +134,7 @@ void CHeaderCtrlFx::OnPaint()
 	int iItemCount = Header_GetItemCount(this->m_hWnd);
 	if (iItemCount > 0)
 	{
-		Header_GetItemRect(this->m_hWnd, iItemCount - 1, &rectRightItem);
+		Header_GetItemRect(this->m_hWnd, (WPARAM)iItemCount - 1, &rectRightItem);
 		RECT rectClient;
 		GetClientRect(&rectClient);
 		if (rectRightItem.right < rectClient.right)

--- a/Priscilla/MainDialogFx.cpp
+++ b/Priscilla/MainDialogFx.cpp
@@ -242,7 +242,7 @@ void CMainDialogFx::InitMenu()
 	UINT newItemID = 0;
 	UINT currentItemID = 0;
 	UINT defaultStyleItemID = 0;
-	UINT defaultLanguageItemID = 0;
+	//UINT defaultLanguageItemID = 0;
 	WIN32_FIND_DATA findData;
 	 
 	HANDLE hFind;
@@ -398,7 +398,7 @@ void CMainDialogFx::ChangeTheme(CString themeName)
 BOOL CMainDialogFx::OnCommand(WPARAM wParam, LPARAM lParam) 
 {
 	// Select Theme
-	if(WM_THEME_ID <= wParam && wParam < WM_THEME_ID + (UINT)m_MenuArrayTheme.GetSize())
+	if(WM_THEME_ID <= wParam && wParam < WM_THEME_ID + (WPARAM)m_MenuArrayTheme.GetSize())
 	{
 		CMenu menu;
 		CMenu subMenu;
@@ -513,14 +513,14 @@ COLORREF CMainDialogFx::GetControlColor(CString name, BYTE defaultColor, CString
 
 BYTE CMainDialogFx::GetControlAlpha(CString name, BYTE defaultAlpha, CString theme)
 {
-	BYTE alpha = GetPrivateProfileInt(L"Alpha", name, defaultAlpha, theme);
+	BYTE alpha = (BYTE)GetPrivateProfileInt(L"Alpha", name, defaultAlpha, theme);
 	
 	return alpha;
 }
 
 BYTE CMainDialogFx::GetCharacterPosition(CString theme)
 {
-	BYTE position = GetPrivateProfileInt(L"Character", L"Position", 0, theme);
+	BYTE position = (BYTE)GetPrivateProfileInt(L"Character", L"Position", 0, theme);
 
 	return position;
 }

--- a/Priscilla/OsInfoFx.cpp
+++ b/Priscilla/OsInfoFx.cpp
@@ -19,14 +19,17 @@ BOOL IsX64()
 	if (b == -1)
 	{
 		b = FALSE;
-		SYSTEM_INFO si = { 0 };
-		FuncGetNativeSystemInfo pGetNativeSystemInfo = (FuncGetNativeSystemInfo)GetProcAddress(GetModuleHandle(L"kernel32"), "GetNativeSystemInfo");
-		if (pGetNativeSystemInfo != NULL)
-		{
-			pGetNativeSystemInfo(&si);
-			if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64)
+		HMODULE dll_kernel32 = GetModuleHandleW(L"kernel32");
+		if (dll_kernel32) {
+			FuncGetNativeSystemInfo pGetNativeSystemInfo = (FuncGetNativeSystemInfo)GetProcAddress(dll_kernel32, "GetNativeSystemInfo");
+			if (pGetNativeSystemInfo != NULL)
 			{
-				b = TRUE;
+				SYSTEM_INFO si{};
+				pGetNativeSystemInfo(&si);
+				if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64)
+				{
+					b = TRUE;
+				}
 			}
 		}
 	}
@@ -39,14 +42,17 @@ BOOL IsIa64()
 	if (b == -1)
 	{
 		b = FALSE;
-		SYSTEM_INFO si = { 0 };
-		FuncGetNativeSystemInfo pGetNativeSystemInfo = (FuncGetNativeSystemInfo)GetProcAddress(GetModuleHandle(L"kernel32"), "GetNativeSystemInfo");
-		if (pGetNativeSystemInfo != NULL)
-		{
-			pGetNativeSystemInfo(&si);
-			if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_IA64)
+		HMODULE dll_kernel32 = GetModuleHandleW(L"kernel32");
+		if (dll_kernel32) {
+			FuncGetNativeSystemInfo pGetNativeSystemInfo = (FuncGetNativeSystemInfo)GetProcAddress(dll_kernel32, "GetNativeSystemInfo");
+			if (pGetNativeSystemInfo != NULL)
 			{
-				b = TRUE;
+				SYSTEM_INFO si{};
+				pGetNativeSystemInfo(&si);
+				if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_IA64)
+				{
+					b = TRUE;
+				}
 			}
 		}
 	}
@@ -59,14 +65,17 @@ BOOL IsArm32()
 	if (b == -1)
 	{
 		b = FALSE;
-		SYSTEM_INFO si = { 0 };
-		FuncGetNativeSystemInfo pGetNativeSystemInfo = (FuncGetNativeSystemInfo)GetProcAddress(GetModuleHandle(L"kernel32"), "GetNativeSystemInfo");
-		if (pGetNativeSystemInfo != NULL)
-		{
-			pGetNativeSystemInfo(&si);
-			if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM)
+		HMODULE dll_kernel32 = GetModuleHandleW(L"kernel32");
+		if (dll_kernel32) {
+			FuncGetNativeSystemInfo pGetNativeSystemInfo = (FuncGetNativeSystemInfo)GetProcAddress(dll_kernel32, "GetNativeSystemInfo");
+			if (pGetNativeSystemInfo != NULL)
 			{
-				b = TRUE;
+				SYSTEM_INFO si{};
+				pGetNativeSystemInfo(&si);
+				if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM)
+				{
+					b = TRUE;
+				}
 			}
 		}
 	}
@@ -79,14 +88,17 @@ BOOL IsArm64()
 	if (b == -1)
 	{
 		b = FALSE;
-		SYSTEM_INFO si = { 0 };
-		FuncGetNativeSystemInfo pGetNativeSystemInfo = (FuncGetNativeSystemInfo)GetProcAddress(GetModuleHandle(L"kernel32"), "GetNativeSystemInfo");
-		if (pGetNativeSystemInfo != NULL)
-		{
-			pGetNativeSystemInfo(&si);
-			if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM64)
+		HMODULE dll_kernel32 = GetModuleHandleW(L"kernel32");
+		if (dll_kernel32) {
+			FuncGetNativeSystemInfo pGetNativeSystemInfo = (FuncGetNativeSystemInfo)GetProcAddress(dll_kernel32, "GetNativeSystemInfo");
+			if (pGetNativeSystemInfo != NULL)
 			{
-				b = TRUE;
+				SYSTEM_INFO si{};
+				pGetNativeSystemInfo(&si);
+				if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM64)
+				{
+					b = TRUE;
+				}
 			}
 		}
 	}
@@ -99,10 +111,13 @@ BOOL IsWow64()
 	if (b == -1)
 	{
 		b = FALSE;
-		FuncIsWow64Process pIsWow64Process = (FuncIsWow64Process)GetProcAddress(GetModuleHandle(L"kernel32"), "IsWow64Process");
-		if (pIsWow64Process != NULL)
-		{
-			pIsWow64Process(GetCurrentProcess(), &b);
+		HMODULE dll_kernel32 = GetModuleHandleW(L"kernel32");
+		if (dll_kernel32) {
+			FuncIsWow64Process pIsWow64Process = (FuncIsWow64Process)GetProcAddress(dll_kernel32, "IsWow64Process");
+			if (pIsWow64Process != NULL)
+			{
+				pIsWow64Process(GetCurrentProcess(), &b);
+			}
 		}
 	}
 	return b;
@@ -220,7 +235,7 @@ BOOL IsNT5()
 	static BOOL b = -1;
 	if (b == -1)
 	{
-		b = FALSE;
+		/*b = FALSE;
 		OSVERSIONINFOEX osvi;
 		ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
 		osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
@@ -229,7 +244,9 @@ BOOL IsNT5()
 		if (osvi.dwMajorVersion == 5)
 		{
 			b = TRUE;
-		}
+		}*/
+
+		b = !UtilityFx__IsWindowsVersionOrGreater(6, 0) && UtilityFx__IsWindowsVersionOrGreater(5, 0) ? TRUE : FALSE;
 	}
 	return b;
 }
@@ -239,7 +256,7 @@ BOOL IsNT6orLater()
 	static BOOL b = -1;
 	if (b == -1)
 	{
-		b = FALSE;
+		/*b = FALSE;
 		OSVERSIONINFOEX osvi;
 		ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
 		osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
@@ -248,7 +265,8 @@ BOOL IsNT6orLater()
 		if (osvi.dwMajorVersion >= 6)
 		{
 			b = TRUE;
-		}
+		}*/
+		b = UtilityFx__IsWindowsVersionOrGreater(6, 0) ? TRUE : FALSE;
 	}
 	return b;
 }
@@ -258,7 +276,7 @@ BOOL IsWin2k()
 	static BOOL b = -1;
 	if (b == -1)
 	{
-		b = FALSE;
+		/*b = FALSE;
 		OSVERSIONINFOEX osvi;
 		ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
 		osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
@@ -267,7 +285,8 @@ BOOL IsWin2k()
 		if (osvi.dwMajorVersion == 5 && osvi.dwMinorVersion == 0)
 		{
 			b = TRUE;
-		}
+		}*/
+		b = UtilityFx__IsWindowsVersionOrGreater(5, 0) && !UtilityFx__IsWindowsVersionOrGreater(5, 1) ? TRUE : FALSE;
 	}
 	return b;
 }
@@ -277,7 +296,7 @@ BOOL IsWinXpOrLater()
 	static BOOL b = -1;
 	if (b == -1)
 	{
-		b = FALSE;
+		/*b = FALSE;
 		OSVERSIONINFOEX osvi;
 		ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
 		osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
@@ -290,7 +309,8 @@ BOOL IsWinXpOrLater()
 		else if (osvi.dwMajorVersion >= 6)
 		{
 			b = TRUE;
-		}
+		}*/
+		b = UtilityFx__IsWindowsVersionOrGreater(5, 1) ? TRUE : FALSE;
 	}
 	return b;
 }
@@ -301,7 +321,7 @@ BOOL IsWinXpLuna()
 	BOOL b = FALSE;
 	if (xp == -1)
 	{
-		xp = FALSE;
+		/*xp = FALSE;
 		OSVERSIONINFOEX osvi;
 		ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
 		osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
@@ -310,7 +330,8 @@ BOOL IsWinXpLuna()
 		if (osvi.dwMajorVersion == 5)
 		{
 			xp = TRUE;
-		}
+		}*/
+		xp = UtilityFx__IsWindowsVersionOrGreater(5, 0) && !UtilityFx__IsWindowsVersionOrGreater(6, 0) ? TRUE : FALSE;
 	}
 	if (xp == FALSE)
 	{ 
@@ -344,7 +365,7 @@ BOOL IsWin8orLater()
 	static BOOL b = -1;
 	if (b == -1)
 	{
-		b = FALSE;
+		/*b = FALSE;
 		OSVERSIONINFOEX osvi;
 		ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
 		osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
@@ -354,14 +375,15 @@ BOOL IsWin8orLater()
 		{
 			b = FALSE;
 		}
-		else if (osvi.dwMajorVersion == 6 && osvi.dwMinorVersion <= 1)
+		else if (/osvi.dwMajorVersion == 6 && osvi.dwMinorVersion <= 1)
 		{
 			b = FALSE;
 		}
 		else
 		{
 			b = TRUE;
-		}
+		}*/
+		b = UtilityFx__IsWindowsVersionOrGreater(6, 2) ? TRUE : FALSE;
 	}
 	return b;
 }
@@ -371,7 +393,7 @@ BOOL IsWin81orLater()
 	static BOOL b = -1;
 	if (b == -1)
 	{
-		b = FALSE;
+		/*b = FALSE;
 		OSVERSIONINFOEX osvi;
 		ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
 		osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
@@ -388,7 +410,8 @@ BOOL IsWin81orLater()
 		else
 		{
 			b = TRUE;
-		}
+		}*/
+		b = UtilityFx__IsWindowsVersionOrGreater(6, 3) ? TRUE : FALSE;
 	}
 	return b;
 }
@@ -398,7 +421,8 @@ BOOL IsDarkModeSupport()
 	static BOOL b = -1;
 	if (b == -1)
 	{
-		b = FALSE;
+		b = UtilityFx__IsWindowBuildOrNewer(17763) ? TRUE : FALSE;
+		/*b = FALSE;
 		OSVERSIONINFOEX osvi;
 		ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
 		osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
@@ -407,7 +431,7 @@ BOOL IsDarkModeSupport()
 		if (osvi.dwBuildNumber >= 17763) // Windows 10 Ver.1809 or later
 		{
 			b = TRUE;
-		}
+		}*/
 	}
 	return b;
 }
@@ -481,7 +505,7 @@ DWORD GetIeVersion()
 
 DWORD GetWin10Version()
 {
-	OSVERSIONINFOEX osvi;
+	/*OSVERSIONINFOEX osvi;
 	ZeroMemory(&osvi, sizeof(OSVERSIONINFOEX));
 	osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
 	GetVersionEx((OSVERSIONINFO*)&osvi);
@@ -496,6 +520,18 @@ DWORD GetWin10Version()
 	else if (osvi.dwBuildNumber >= 14393) { return 1607; }
 	else if (osvi.dwBuildNumber >= 10586) { return 1511; }
 	else if (osvi.dwBuildNumber >= 10240) { return 1507; }
+	else { return 0; }*/
+
+	if (UtilityFx__IsWindowBuildOrNewer(19041)) { return 2004; }
+	else if (UtilityFx__IsWindowBuildOrNewer(18363)) { return 1909; }
+	else if (UtilityFx__IsWindowBuildOrNewer(18362)) { return 1903; }
+	else if (UtilityFx__IsWindowBuildOrNewer(17763)) { return 1809; }
+	else if (UtilityFx__IsWindowBuildOrNewer(17134)) { return 1803; }
+	else if (UtilityFx__IsWindowBuildOrNewer(16299)) { return 1709; }
+	else if (UtilityFx__IsWindowBuildOrNewer(15063)) { return 1703; }
+	else if (UtilityFx__IsWindowBuildOrNewer(14393)) { return 1607; }
+	else if (UtilityFx__IsWindowBuildOrNewer(10586)) { return 1511; }
+	else if (UtilityFx__IsWindowBuildOrNewer(10240)) { return 1507; }
 	else { return 0; }
 }
 

--- a/Priscilla/SliderCtrlFx.cpp
+++ b/Priscilla/SliderCtrlFx.cpp
@@ -19,6 +19,7 @@ CSliderCtrlFx::CSliderCtrlFx()
 	m_RenderMode = SystemDraw;
 	m_bHighContrast = FALSE;
 	m_bDarkMode = FALSE;
+	m_bBkBitmapInit = FALSE;
 }
 
 CSliderCtrlFx::~CSliderCtrlFx()

--- a/Priscilla/SliderCtrlFx.h
+++ b/Priscilla/SliderCtrlFx.h
@@ -22,7 +22,7 @@ public:
 	virtual ~CSliderCtrlFx();
 	BOOL InitControl(int x, int y, int width, int height, double zoomRatio, CDC* bkDC, int renderMode, BOOL bHighContrast, BOOL bDarkMode, int min, int max, int pos);
 
-	BOOL m_bHighContrast;
+	BOOL m_bHighContrast{};
 	CBrush m_BkBrush;
 
 protected:
@@ -30,18 +30,18 @@ protected:
 	void SetBkReload(void);
 	void LoadCtrlBk(CDC* drawDC);
 
-	int m_X;
-	int m_Y;
+	int m_X{};
+	int m_Y{};
 	CSize m_CtrlSize;
 	CRect m_Margin;
-	int m_RenderMode;
-	BOOL m_bDarkMode;
+	int m_RenderMode{};
+	BOOL m_bDarkMode{};
 
 	// Image
 	CDC* m_BkDC;
 	CBitmap m_BkBitmap;
-	BOOL m_bBkBitmapInit;
-	BOOL m_bBkLoad;
+	BOOL m_bBkBitmapInit{};
+	BOOL m_bBkLoad{};
 	CBitmap m_CtrlBitmap;
 	CImage m_CtrlImage;
 };

--- a/Priscilla/StaticFx.cpp
+++ b/Priscilla/StaticFx.cpp
@@ -157,10 +157,13 @@ BOOL CStaticFx::InitControl(int x, int y, int width, int height, double zoomRati
 			a = 0;
 		}
 
+		const int max_length = length;
+
 		for (int y = 0; y < (int)(m_CtrlSize.cy * m_ImageCount); y++)
 		{
 			for (int x = 0; x < m_CtrlSize.cx; x++)
 			{
+				if ((y * m_CtrlSize.cx + x) * 4 + 4 > max_length) continue;//over run
 				bitmapBits[(y * m_CtrlSize.cx + x) * 4 + 0] = b;
 				bitmapBits[(y * m_CtrlSize.cx + x) * 4 + 1] = g;
 				bitmapBits[(y * m_CtrlSize.cx + x) * 4 + 2] = r;
@@ -335,6 +338,7 @@ void CStaticFx::DrawControl(CDC* drawDC, LPDRAWITEMSTRUCT lpDrawItemStruct, CBit
 			}
 			else
 			{
+				const int buffer_max = (int)(CtlMemSize > DstMemSize ? DstMemSize : CtlMemSize);
 				int baseY = m_CtrlSize.cy * no;
 				for (LONG py = 0; py < DstBmpInfo.bmHeight; py++)
 				{
@@ -342,6 +346,7 @@ void CStaticFx::DrawControl(CDC* drawDC, LPDRAWITEMSTRUCT lpDrawItemStruct, CBit
 					int cn = (baseY + py) * CtlLineBytes;
 					for (LONG px = 0; px < DstBmpInfo.bmWidth; px++)
 					{
+						if (cn + 4 > buffer_max || dn + 4 > buffer_max)  continue;//buffer over run
 						BYTE a = CtlBuffer[cn + 3];
 						BYTE na = 255 - a;
 						DstBuffer[dn + 0] = (BYTE)((CtlBuffer[cn + 0] * a + DstBuffer[dn + 0] * na) / 255);

--- a/Priscilla/UtilityFx.cpp
+++ b/Priscilla/UtilityFx.cpp
@@ -85,11 +85,11 @@ void DebugPrint(CString cstr)
 int GetFileVersion(const TCHAR* file, TCHAR* version)
 {
 	ULONG reserved = 0;
-	VS_FIXEDFILEINFO vffi;
+	VS_FIXEDFILEINFO vffi{};
 	TCHAR* buf = NULL;
 	int  Locale = 0;
-	TCHAR str[256];
-	str[0] = '\0';
+	TCHAR str[256]{};
+	//str[0] = '\0';
 
 	UINT size = GetFileVersionInfoSize((TCHAR*)file, &reserved);
 	TCHAR* vbuf = new TCHAR[size];
@@ -152,7 +152,9 @@ ULONGLONG GetTickCountFx()
 	}
 	else
 	{
+#pragma warning( disable : 28159 )
 		return (ULONGLONG)GetTickCount();
+#pragma warning( default : 28159 )
 	}
 }
 
@@ -181,6 +183,44 @@ DWORD B8toB32(BYTE b0, BYTE b1, BYTE b2, BYTE b3)
 
 	return data;
 }
+
+
+//+ 20220502
+/*
+need manifest
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+*/
+bool UtilityFx__IsWindowsVersionOrGreater(WORD wMajorVersion, WORD wMinorVersion, WORD wServicePackMajor) {
+	OSVERSIONINFOEXW osvi = { sizeof(osvi), 0, 0, 0, 0, {0}, 0, 0 };
+	DWORDLONG        const dwlConditionMask = VerSetConditionMask(
+		VerSetConditionMask(
+			VerSetConditionMask(
+				0, VER_MAJORVERSION, VER_GREATER_EQUAL),
+			VER_MINORVERSION, VER_GREATER_EQUAL),
+		VER_SERVICEPACKMAJOR, VER_GREATER_EQUAL);
+
+	osvi.dwMajorVersion = wMajorVersion;
+	osvi.dwMinorVersion = wMinorVersion;
+	osvi.wServicePackMajor = wServicePackMajor;
+
+	return VerifyVersionInfoW(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR, dwlConditionMask) != FALSE;
+}
+bool UtilityFx__IsWindowBuildOrNewer(DWORD v) {
+	OSVERSIONINFOEXW osver = { sizeof(OSVERSIONINFOEXW) };
+	osver.dwBuildNumber = v;
+	return (VerifyVersionInfoW(&osver, VER_BUILDNUMBER, VerSetConditionMask(0, VER_BUILDNUMBER, VER_GREATER_EQUAL)) == TRUE);
+}
+
+
 
 ////------------------------------------------------
 //   .ini support function

--- a/Priscilla/UtilityFx.h
+++ b/Priscilla/UtilityFx.h
@@ -30,6 +30,11 @@ ULONGLONG GetTickCountFx();
 ULONG64 B8toB64(BYTE b0, BYTE b1 = 0, BYTE b2 = 0, BYTE b3 = 0, BYTE b4 = 0, BYTE b5 = 0, BYTE b6 = 0, BYTE b7 = 0);
 DWORD B8toB32(BYTE b0, BYTE b1 = 0, BYTE b2 = 0, BYTE b3 = 0);
 
+//+ 20220502
+bool UtilityFx__IsWindowsVersionOrGreater(WORD wMajorVersion, WORD wMinorVersion, WORD wServicePackMajor = 0);
+//+ 20220508
+bool UtilityFx__IsWindowBuildOrNewer(DWORD v);
+
 ////------------------------------------------------
 //   .ini support function
 ////------------------------------------------------

--- a/SettingDlg.cpp
+++ b/SettingDlg.cpp
@@ -277,7 +277,7 @@ void CSettingDlg::InitSelectDisk()
 			driveLetter.Format(_T("(%s)"), p->m_Ata.vars[i].DriveMap.GetString());
 		}
 
-		cstr.Format(_T("(%02d) %s %s %s"), i + 1, p->m_Ata.vars.GetAt(i).Model.GetString(), temp, driveLetter);
+		cstr.Format(_T("(%02d) %s %s %s"), i + 1, p->m_Ata.vars.GetAt(i).Model.GetString(), temp.GetString(), driveLetter.GetString());
 		m_CtrlSelectDisk.AddString(cstr);
 
 		if (i == p->GetSelectedDrive())
@@ -305,7 +305,7 @@ void CSettingDlg::OnEnableAam()
 	}
 
 	int targetValue = m_AamScrollbar.GetScrollPos();
-	p->m_Ata.EnableAam(m_DiskIndex, targetValue);
+	p->m_Ata.EnableAam(m_DiskIndex, (BYTE)targetValue);
 	p->m_Ata.UpdateIdInfo(m_DiskIndex);
 
 	if(p->m_Ata.vars.GetAt(m_DiskIndex).IsAamEnabled)
@@ -358,7 +358,7 @@ void  CSettingDlg::OnEnableApm()
 	}
 
 	int targetValue = m_ApmScrollbar.GetScrollPos();
-	p->m_Ata.EnableApm(m_DiskIndex, targetValue);
+	p->m_Ata.EnableApm(m_DiskIndex, (BYTE)targetValue);
 	p->m_Ata.UpdateIdInfo(m_DiskIndex);
 
 	if(p->m_Ata.vars.GetAt(m_DiskIndex).IsApmEnabled)

--- a/TemperatureDlg.cpp
+++ b/TemperatureDlg.cpp
@@ -160,9 +160,9 @@ void CTemperatureDlg::InitSelectDisk()
 		}
 		else
 		{
-			driveLetter.Format(_T("(%s)"), p->m_Ata.vars[i].DriveMap);
+			driveLetter.Format(_T("(%s)"), p->m_Ata.vars[i].DriveMap.GetString());
 		}
-		cstr.Format(_T("(%02d) %s %s %s"), i + 1, p->m_Ata.vars.GetAt(i).Model, temp, driveLetter);
+		cstr.Format(_T("(%02d) %s %s %s"), i + 1, p->m_Ata.vars.GetAt(i).Model.GetString(), temp.GetString(), driveLetter.GetString());
 
 		m_CtrlSelectDisk.AddString(cstr);
 		if (i == p->GetSelectedDrive())


### PR DESCRIPTION
Fixed some buffer overruns(Possible crash due to heap corruption) and compilation errors in C ++ 23 compliance.
I want you to start it as a test build instead of applying it to a release build suddenly.

i mistake olf pull request commits.
recreate new pull request(ver2) this.

### AtaSmart.cpp, .h

- AMD RAID : ARM64 not use
> _M_ARM → _M_ARM && _M_ARM64

- disable warning26812
>define position change (push, pop over line)
>C26812 : enum.3

- fix warning
>LNT-logical-bitwise-mismatch
>C26495 : uninitialize value

### SlotSpeedGetter.cpp
- No need Cfgmgr32.lib

- safe Dynamic DLL load
>Setupapi.dll
>SetupDiGetDevicePropertyW
>Dealing with cases where getting dynamic libraries and functions fails
>C6387

-  fix buffer over run
>CM_Get_Device_ID(W)
>In the case of UNICORD, the buffer size is doubled(buffer over run)
>C6386

###  Prscilla/UtilityFx.cpp
-  disable warning GetTickCount() on 64bit
>C28159

- fix warning
>LNT-uninitialized-local

### Prscilla/ListCtrlFx.cpp
>2 fix buffer over run

### etc.
- literal const, result, uninit handling
>C2440
>C28193
>C26495
>C2664
>C28159
>C6284
>C6328
>C2664
>LNT-arithmetic-overflow
>LNT-uninitialized-local