### PR TITLE
Sandisk/WD CloudSpeed Gen. II SSD Support #207

### DIFF
--- a/AtaSmart.h
+++ b/AtaSmart.h
@@ -234,6 +234,7 @@ public:
 		SSD_VENDOR_SANDISK_HP_VENUS = 45,
 		SSD_VENDOR_SANDISK_LENOVO = 46,
 		SSD_VENDOR_SANDISK_LENOVO_HELEN_VENUS = 47,
+		SSD_VENDOR_SANDISK_CLOUD = 48,
 
 		SSD_VENDOR_MAX = 99,
 
@@ -1835,6 +1836,7 @@ public:
 		BOOL				FlagLifeSanDisk0_1{};
 		BOOL				FlagLifeSanDisk1{};
 		BOOL				FlagLifeSanDiskLenovo{};
+		BOOL				FlagLifeSanDiskCloud{};
 
 		DWORD				Major{};
 		DWORD				Minor{};


### PR DESCRIPTION
resolves #207
Add support for CloudSpeed Gen. II SSDs
To show life time and read/write bytes.
[https://support-en.wd.com/app/answers/detailweb/a_id/45405/~/cloudspeed-gen.-ii-ssd-support-information](https://support-en.wd.com/app/answers/detailweb/a_id/45405/~/cloudspeed-gen.-ii-ssd-support-information)

Note: To show attributes properly I did add new section into English.lang file. Here is content:


```
[SmartCloudSpeedGenII] ;Added 8.18.0
05=Retired Block Count                      
09=Power On Hours
0D=Count of Uncorrectable ECC Errors
20=Write Amplification multiplied by 100
21=Write Amplification Factor
AA=Reserve Block Count
AB=Program Fail Count
AC=Erase Fail Count
AD=Average Write/Erase Count
AE=Unexpected Power Loss Count
B2=SSD Life Left (upto 0.01%)
BF=Clean Shutdown Count
C0=Unclean Shutdown Count
C2=Temperature
C4=Number of Blocks Reallocated
E6=Percent of Total Write/Erase Count
E8=Spare Blocks Remaining
E9=Total Nand Writes 64GB
EB=Capacitor Health
F1=Total Host Writes 64GB
F2=Total Host Reads 64GB
F4=Lifetime Thermal Throttle Activations
F5=Percent Drive Life Remaining
FD=SPI Tests Remaining

```

Here is example output what I've got after update:
![1676685794863](https://user-images.githubusercontent.com/6795932/219825973-f134384b-b18b-4bb8-b5aa-678af1af542a.png)
