### PR TITLE
CAtaSmart: CorrectAttribute, AMD_RC2 fix

### DIFF
--- a/AtaSmart.h
+++ b/AtaSmart.h
@@ -1855,9 +1855,9 @@ public:
 		INT 				AlarmTemperature{};
 		BOOL				AlarmHealthStatus{};
 
-		INTERFACE_TYPE		InterfaceType;
-		COMMAND_TYPE		CommandType;
-		HOST_READS_WRITES_UNIT HostReadsWritesUnit;
+		INTERFACE_TYPE		InterfaceType{};
+		COMMAND_TYPE		CommandType{};
+		HOST_READS_WRITES_UNIT HostReadsWritesUnit{};
 
 		DWORD				DiskVendorId{};
 		DWORD				UsbVendorId{};
@@ -1869,7 +1869,7 @@ public:
 		WORD				ThresholdC6{};
 		WORD				ThresholdFF{};
 
-		CSMI_SAS_PHY_ENTITY sasPhyEntity;
+		CSMI_SAS_PHY_ENTITY sasPhyEntity{};
 
 		CString				SerialNumber;
 		CString				SerialNumberReverse;
@@ -1951,6 +1951,7 @@ public:
 	DWORD CsmiType = 0;
 
 	DWORD CheckDiskStatus(DWORD index);
+	DWORD CorrectDiskAttributeStatus(DWORD index, BYTE(&status)[MAX_ATTRIBUTE], UINT RawValueFormat, TCHAR(&text)[MAX_ATTRIBUTE][5][32]) const;
 
 protected:
 

--- a/DiskInfoDlgUpdate.cpp
+++ b/DiskInfoDlgUpdate.cpp
@@ -303,25 +303,79 @@ BOOL CDiskInfoDlg::UpdateListCtrl(DWORD i)
 	}
 
 	CString cstr;
-	DWORD caution = 0;
+	//DWORD caution = 0;
 	UINT mask = LVIF_IMAGE;
 
 	DWORD k = 0;
 
-	TCHAR str[256];
-	CString unknown;
+	TCHAR str[256]{};
+	//CString unknown;
 	CString vendorSpecific;
 
 	//	unknown = i18n(_T("Smart"), _T("UNKNOWN"), m_bSmartEnglish);
 	vendorSpecific = i18n(_T("Smart"), _T("VENDOR_SPECIFIC"), m_bSmartEnglish);
 
-	for (DWORD j = 0; j < m_Ata.vars[i].AttributeCount; j++)
+	BYTE attr_status[CAtaSmart::MAX_ATTRIBUTE]{};
+	TCHAR attr_text[CAtaSmart::MAX_ATTRIBUTE][5][32]{};
+	const DWORD attr_status_highest = m_Ata.CorrectDiskAttributeStatus(i, attr_status, m_RawValues, attr_text);
+	const UINT ICON_GOOD1 = ICON_GOOD + m_bGreenMode;
+
+	for (UINT_PTR j = 0; j < m_Ata.vars[i].AttributeCount && j < CAtaSmart::MAX_ATTRIBUTE; ++j)
 	{
 		if (m_Ata.vars[i].Attribute[j].Id == 0x00 || m_Ata.vars[i].Attribute[j].Id == 0xFF)
 		{
 			continue;
 		}
 
+		UINT icon = ICON_UNKNOWN;
+		if (attr_status_highest) {
+			switch (attr_status[j]) {
+			case CAtaSmart::DISK_STATUS_GOOD:
+				icon = ICON_GOOD1;
+				break;
+			case CAtaSmart::DISK_STATUS_CAUTION:
+				icon = ICON_CAUTION;
+				break;
+			case CAtaSmart::DISK_STATUS_BAD:
+				icon = ICON_BAD;
+				break;
+			}
+		}
+
+		if (flag)
+		{
+			m_List.SetItem(k, 0, mask, _T(""), icon, 0, 0, 0, 0);
+		}
+		else
+		{
+			m_List.InsertItem(k, _T(""), icon);
+		}
+
+
+		m_List.SetItemText(k, 1, attr_text[j][0]);
+		if (m_bSmartEnglish)
+		{
+			GetPrivateProfileStringFx(m_Ata.vars[i].SmartKeyName, attr_text[j][0], vendorSpecific, str, 256, m_DefaultLangPath);
+		}
+		else
+		{
+			GetPrivateProfileStringFx(m_Ata.vars[i].SmartKeyName, attr_text[j][0], L"", str, 256, m_DefaultLangPath);
+			CString en = str;
+			if (en.IsEmpty())
+			{
+				GetPrivateProfileStringFx(m_Ata.vars[i].SmartKeyName, attr_text[j][0], vendorSpecific, str, 256, m_CurrentLangPath);
+			}
+			else
+			{
+				GetPrivateProfileStringFx(m_Ata.vars[i].SmartKeyName, attr_text[j][0], en, str, 256, m_CurrentLangPath);
+			}
+		}
+		m_List.SetItemText(k, 2, str);
+		for (int j2 = 3; j2 < 7; ++j2) {
+			m_List.SetItemText(k, j2, attr_text[j][j2 - 2]);
+		}
+
+#if 0
 		if (m_Ata.vars[i].IsNVMe)
 		{
 			UINT icon = ICON_GOOD + m_bGreenMode;
@@ -1021,6 +1075,7 @@ BOOL CDiskInfoDlg::UpdateListCtrl(DWORD i)
 			//	m_List.SetItemText(k, 6, _T("DDDDDDDDDDDD"));
 			m_List.SetItemText(k, 6, cstr);
 		}
+#endif
 
 		k++;
 	}
@@ -1613,7 +1668,7 @@ GPL: General Purpose Log\n\
 		m_Feature.Delete(m_Feature.GetLength() - 2, 2);
 	}
 
-	if (m_Ata.vars[i].CommandType == m_Ata.CMD_TYPE_AMD_RC2 || m_Ata.vars[i].CommandType == m_Ata.CMD_TYPE_JMS56X || m_Ata.vars[i].CommandType == m_Ata.CMD_TYPE_JMB39X)
+	if (/*m_Ata.vars[i].CommandType == m_Ata.CMD_TYPE_AMD_RC2 || */m_Ata.vars[i].CommandType == m_Ata.CMD_TYPE_JMS56X || m_Ata.vars[i].CommandType == m_Ata.CMD_TYPE_JMB39X)
 	{
 		m_Feature = L"";
 	}


### PR DESCRIPTION
English
---

**Bug fixes:**
[AMD_RC2]
- Fixed the problem that TotalDiskSize may not be reflected correctly
- Change to display "S.M.A.R.T." in the corresponding function when SMART content is available (suggestion)

**Suggested changes:**
[CAtaSmart::CorrectDiskAttributeStatus]
- Adjusted by moving the hardware information in the CDiskInfoDlg::UpdateListCtrl function to the CorrectDiskAttributeStatus created in CAtaSmart.

1. The content is similar to CAtaSmart::CheckDiskStatus, so it will be easier to maintain in CAtaSmart.
2. Since CAtaSmart can manage information for each Attribute, the UI part can be devoted to the UI.

my best regards,

Japanese
---

**不具合修正:**
[AMD_RC2]
- TotalDiskSizeが正しく表示に反映されない場合がある問題の修正
- SMARTの内容がとれる場合、対応機能に「S.M.A.R.T.」の表記を出すように変更（提案）

**提案としての変更:**
[CAtaSmart::CorrectDiskAttributeStatus]
- CDiskInfoDlg::UpdateListCtrl関数内にある、ハードウェア情報で分岐する内容を、CAtaSmartに作成したCorrectDiskAttributeStatusに移動して調整。

1. CAtaSmart::CheckDiskStatusと類似した内容なので、CAtaSmart内にまとめたほうが今後のメンテナンスが楽になる。
2. CAtaSmartで完結してAttribute単位の情報を管理できるため、UI部分はUIに専念できる。

よろしくお願いいたします。