### PR TITLE
Fix resource leaks

### DIFF
--- a/SlotSpeedGetter.cpp
+++ b/SlotSpeedGetter.cpp
@@ -177,6 +177,7 @@ SlotMaxCurrSpeed GetSlotMaxCurrSpeedFromDeviceID(const CString DeviceID)
 
 		++CurrentDevice;
 	} while (LastResult);
+	SetupDiDestroyDeviceInfoList(ClassDeviceInformations);
 
 	return ConvertOSResult(OSLevelResult);
 }

--- a/SlotSpeedGetter.cpp
+++ b/SlotSpeedGetter.cpp
@@ -53,6 +53,7 @@ CString GetStringValueFromQuery(IWbemServices* pIWbemServices, const CString que
 					VariantClear(&pVal);
 				}
 				VariantInit(&pVal);
+				SAFE_RELEASE(pCOMDev);
 			}
 		}
 	}
@@ -61,7 +62,6 @@ CString GetStringValueFromQuery(IWbemServices* pIWbemServices, const CString que
 		result = L"";
 	}
 
-	SAFE_RELEASE(pCOMDev);
 	SAFE_RELEASE(pEnumCOMDevs);
 	return result;
 }


### PR DESCRIPTION
I have found two places in the code where resources are not released correctly.

It is possible to revert the deletion of `SAFE_RELEASE(pCOMDev);` from line 64 if you believe `VariantInit`, `VariantClear` or `IWbemClassObject::Get` could throw an exception that would skip over line 56.