### PR TITLE
Add fake NVMe drive detection for SanDisk and WD

### DIFF
--- a/AtaSmart.cpp
+++ b/AtaSmart.cpp
@@ -2520,6 +2520,12 @@ VOID CAtaSmart::Init(BOOL useWmi, BOOL advancedDiskSearch, PBOOL flagChangeDisk,
 				{
 					/// PCI Vendor ID for Samsung = 0x144D
 					if (model.Find(_T("SAMSUNG")) >= 0 && vars[i].IdentifyDevice.N.PCIeVID != 0x144D) { flagFake = TRUE; }
+
+					/// PCI Vendor ID for SanDisk/WD = 0x15B7
+					if (model.Find(_T("SANDISK")) >= 0 && vars[i].IdentifyDevice.N.PCIeVID != 0x15B7) { flagFake = TRUE; }
+
+					/// PCI Vendor ID for WD (Western Digital) = 0x15B7
+					if ((model.Find(_T("WDC ")) == 0 || model.Find(_T("WD ")) == 0) && vars[i].IdentifyDevice.N.PCIeVID != 0x15B7) { flagFake = TRUE; }
 				}
 
 				if (flagFake)


### PR DESCRIPTION
## Summary

This PR extends the existing fake Samsung NVMe detection (added in 9.9.1) to also identify counterfeit **SanDisk** and **Western Digital** NVMe drives by verifying the PCIe Vendor ID reported by the drive controller.

## Changes (AtaSmart.cpp)

Inside the `Fake Check` block, within the `CMD_TYPE_JMS586_20` guard:

- `0x15B7` is the official PCI Vendor ID for Western Digital / SanDisk
- SanDisk: `model.Find(_T("SANDISK")) >= 0 && PCIeVID != 0x15B7`  
- WD: `(model starts with 'WDC ' or 'WD ') && PCIeVID != 0x15B7`  
- Both reuse the existing `CMD_TYPE_JMS586_20` exclusion (USB RAID enclosures)
- Flagged drives get the `[FAKE] ` prefix, identical to the Samsung behaviour